### PR TITLE
Add EN/CN frontend language toggle

### DIFF
--- a/backend/internal/app/codex_keeper_test.go
+++ b/backend/internal/app/codex_keeper_test.go
@@ -214,9 +214,10 @@ func TestKeeperLogsUseStandardFileFormatAndCanBeCleared(t *testing.T) {
 	if len(status.Logs) == 0 {
 		t.Fatal("status logs are empty, want daemon start log")
 	}
-	assertStandardKeeperLogLine(t, status.Logs[len(status.Logs)-1])
+	lastLog := status.Logs[len(status.Logs)-1]
+	assertStandardKeeperLogLine(t, lastLog)
 
-	logPath := filepath.Join(dataDir, "logs", "codex-keeper-"+time.Now().Format("2006-01-02")+".log")
+	logPath := filepath.Join(dataDir, "logs", "codex-keeper-"+keeperLogDate(t, lastLog)+".log")
 	contents, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read keeper log file: %v", err)
@@ -1254,6 +1255,14 @@ func assertStandardKeeperLogLine(t *testing.T, line string) {
 	if !pattern.MatchString(line) {
 		t.Fatalf("keeper log line %q does not match standard format", line)
 	}
+}
+
+func keeperLogDate(t *testing.T, line string) string {
+	t.Helper()
+	if len(line) < len("time=2006-01-02") || !strings.HasPrefix(line, "time=") {
+		t.Fatalf("keeper log line %q does not include a leading timestamp", line)
+	}
+	return line[len("time="):len("time=2006-01-02")]
 }
 
 func waitForKeeperAccounts(t *testing.T, handler http.Handler, cookies []*http.Cookie, expected int) keeperAccountsResponse {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",
     "build": "vue-tsc -b && vite build",
-    "lint": "eslint . --max-warnings=0"
+    "lint": "eslint . --max-warnings=0",
+    "test:i18n": "node scripts/i18n-smoke.mjs"
   },
   "dependencies": {
     "echarts": "^5.5.1",

--- a/frontend/scripts/i18n-smoke.mjs
+++ b/frontend/scripts/i18n-smoke.mjs
@@ -54,6 +54,8 @@ async function loadI18nWithBrowserStubs(options) {
 }
 
 try {
+  installBrowserStubs({ browserLanguages: ['en-US'] })
+
   let {
     localizedApiErrorMessage,
     localizedKeeperStatusDetail,
@@ -132,5 +134,6 @@ try {
   await server.close()
   delete globalThis.fetch
   delete globalThis.localStorage
+  delete globalThis.navigator
   delete globalThis.document
 }

--- a/frontend/scripts/i18n-smoke.mjs
+++ b/frontend/scripts/i18n-smoke.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+
+import { createServer } from 'vite'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const languageStorageKey = 'cpa-helper-language'
+
+const server = await createServer({
+  root,
+  logLevel: 'error',
+  server: { middlewareMode: true },
+})
+
+let moduleCase = 0
+
+function installBrowserStubs({ storedLanguage = null, browserLanguages = ['en-US'] } = {}) {
+  const store = new Map()
+  if (storedLanguage !== null) {
+    store.set(languageStorageKey, storedLanguage)
+  }
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => store.set(key, String(value)),
+    },
+  })
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      language: browserLanguages[0],
+      languages: browserLanguages,
+    },
+  })
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {
+      documentElement: {
+        lang: '',
+      },
+    },
+  })
+
+  return store
+}
+
+async function loadI18nWithBrowserStubs(options) {
+  const store = installBrowserStubs(options)
+  server.moduleGraph.invalidateAll()
+  const i18n = await server.ssrLoadModule(`/src/shared/i18n/index.ts?case=${moduleCase++}`)
+  return { i18n, store }
+}
+
+try {
+  let {
+    localizedApiErrorMessage,
+    localizedKeeperStatusDetail,
+    localizedServerMessage,
+    setLanguage,
+  } = await server.ssrLoadModule('/src/shared/i18n/index.ts')
+
+  setLanguage('en')
+  assert.equal(localizedApiErrorMessage('validation_error', null), 'Invalid request parameters')
+  assert.equal(localizedApiErrorMessage(null, null), 'Request failed')
+  assert.equal(localizedServerMessage('巡检完成'), 'Inspection complete')
+  assert.equal(
+    localizedServerMessage('巡检完成：健康 1，坏凭证禁用 2，恢复启用 3，优先级降级 4，网络错误 5，缓存跳过 6'),
+    'Inspection complete: 1 healthy, 2 bad credentials disabled, 3 restored, 4 priorities lowered, 5 network errors, 6 skipped by cache',
+  )
+  assert.equal(localizedKeeperStatusDetail('守护运行中'), 'Automatic inspection running')
+
+  setLanguage('zh')
+  assert.equal(localizedApiErrorMessage('validation_error', null), '请求参数无效')
+  assert.equal(localizedApiErrorMessage(null, null), '请求失败')
+  assert.equal(localizedKeeperStatusDetail('守护运行中'), '自动巡检运行中')
+
+  let browserCase = await loadI18nWithBrowserStubs({
+    browserLanguages: ['fr-FR', 'zh-CN', 'en-US'],
+  })
+  assert.equal(browserCase.i18n.currentLanguage.value, 'zh')
+  assert.equal(globalThis.document.documentElement.lang, 'zh-CN')
+  assert.equal(browserCase.store.get(languageStorageKey), 'zh')
+
+  browserCase = await loadI18nWithBrowserStubs({
+    storedLanguage: 'en',
+    browserLanguages: ['zh-CN', 'en-US'],
+  })
+  assert.equal(browserCase.i18n.currentLanguage.value, 'en')
+  assert.equal(globalThis.document.documentElement.lang, 'en')
+  assert.equal(browserCase.store.get(languageStorageKey), 'en')
+  browserCase.i18n.toggleLanguage()
+  await Promise.resolve()
+  assert.equal(browserCase.i18n.currentLanguage.value, 'zh')
+  assert.equal(globalThis.document.documentElement.lang, 'zh-CN')
+  assert.equal(browserCase.store.get(languageStorageKey), 'zh')
+
+  browserCase = await loadI18nWithBrowserStubs({
+    storedLanguage: 'de',
+    browserLanguages: ['es-ES', 'en-US', 'zh-CN'],
+  })
+  assert.equal(browserCase.i18n.currentLanguage.value, 'en')
+
+  ;({ localizedApiErrorMessage, localizedKeeperStatusDetail, localizedServerMessage, setLanguage } =
+    browserCase.i18n)
+  setLanguage('en')
+  assert.equal(
+    localizedApiErrorMessage('validation_error', 'API KEY 描述不能为空'),
+    'API key description is required',
+  )
+  assert.equal(
+    localizedServerMessage('请求体不是有效 JSON'),
+    'Request body is not valid JSON',
+  )
+  assert.equal(localizedKeeperStatusDetail(null), 'Not running')
+
+  const { apiClient } = await server.ssrLoadModule(`/src/shared/api/apiClient.ts?case=${moduleCase++}`)
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 418,
+    statusText: 'I am a teapot',
+    json: async () => {
+      throw new Error('not json')
+    },
+  })
+  await assert.rejects(
+    () => apiClient.get('/broken'),
+    (error) => error instanceof Error && error.message === 'Request failed',
+  )
+} finally {
+  await server.close()
+  delete globalThis.fetch
+  delete globalThis.localStorage
+  delete globalThis.document
+}

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -5,14 +5,21 @@ import {
   NDialogProvider,
   NGlobalStyle,
   NMessageProvider,
+  dateEnUS,
   dateZhCN,
+  enUS,
   zhCN,
   type GlobalThemeOverrides,
 } from 'naive-ui'
 
 import { useThemePreference } from '@/shared/composables/useThemePreference'
+import { useLanguagePreference } from '@/shared/i18n'
 
 const { naiveTheme, naiveThemeIsDark } = useThemePreference()
+const { language } = useLanguagePreference()
+
+const naiveLocale = computed(() => (language.value === 'zh' ? zhCN : enUS))
+const naiveDateLocale = computed(() => (language.value === 'zh' ? dateZhCN : dateEnUS))
 
 const themeOverrides = computed<GlobalThemeOverrides>(() => ({
   common: {
@@ -52,8 +59,8 @@ const themeOverrides = computed<GlobalThemeOverrides>(() => ({
   <NConfigProvider
     :theme="naiveTheme"
     :theme-overrides="themeOverrides"
-    :locale="zhCN"
-    :date-locale="dateZhCN"
+    :locale="naiveLocale"
+    :date-locale="naiveDateLocale"
   >
     <NDialogProvider>
       <NMessageProvider>

--- a/frontend/src/app/layout/AppShell.vue
+++ b/frontend/src/app/layout/AppShell.vue
@@ -23,6 +23,7 @@ import {
   DollarSign,
   Github,
   KeyRound,
+  Languages,
   List,
   ListChecks,
   LogOut,
@@ -39,6 +40,7 @@ import {
 import { getMe, isAuthUser, logout } from '@/features/auth/api/authApi'
 import { useCurrentUser } from '@/features/auth/state/currentUser'
 import { useThemePreference } from '@/shared/composables/useThemePreference'
+import { useI18n } from '@/shared/i18n'
 import { logoUrl } from '@/shared/utils/assets'
 
 const route = useRoute()
@@ -53,6 +55,7 @@ const isRouteTransitioning = ref(false)
 const { currentUser, setCurrentUser } = useCurrentUser()
 const hasLoadedUser = ref(currentUser.value !== null)
 const { isDark, preference, setThemePreference, toggleTheme } = useThemePreference()
+const { language, t, toggleLanguage } = useI18n()
 let navigationFeedbackTimer: number | undefined
 let routeTransitionReleaseTimer: number | undefined
 
@@ -114,26 +117,30 @@ function renderIcon(icon: Component) {
     )
 }
 
-const adminMenuItems: MenuOption[] = [
-  { label: '历史用量', key: '/admin/usage', icon: renderIcon(BarChart3) },
-  { label: '请求明细', key: '/admin/records', icon: renderIcon(List) },
-  { label: '用户管理', key: '/admin/users', icon: renderIcon(Users) },
-  { label: '模型价格', key: '/admin/pricing', icon: renderIcon(DollarSign) },
-  { label: '系统设置', key: '/admin/settings', icon: renderIcon(Settings) },
-]
+const adminMenuItems = computed<MenuOption[]>(() => [
+  { label: t('历史用量', 'Usage History'), key: '/admin/usage', icon: renderIcon(BarChart3) },
+  { label: t('请求明细', 'Request Records'), key: '/admin/records', icon: renderIcon(List) },
+  { label: t('用户管理', 'Users'), key: '/admin/users', icon: renderIcon(Users) },
+  { label: t('模型价格', 'Model Prices'), key: '/admin/pricing', icon: renderIcon(DollarSign) },
+  { label: t('系统设置', 'System Settings'), key: '/admin/settings', icon: renderIcon(Settings) },
+])
 
-const accountInspectionMenuItems: MenuOption[] = [
-  { label: '巡检设置', key: '/admin/account-inspection', icon: renderIcon(Activity) },
-  { label: '账号状态', key: '/admin/account-status', icon: renderIcon(ListChecks) },
-]
+const accountInspectionMenuItems = computed<MenuOption[]>(() => [
+  {
+    label: t('巡检设置', 'Inspection Settings'),
+    key: '/admin/account-inspection',
+    icon: renderIcon(Activity),
+  },
+  { label: t('账号状态', 'Account Status'), key: '/admin/account-status', icon: renderIcon(ListChecks) },
+])
 
-const accountMenuItems: MenuOption[] = [
-  { label: '我的用量', key: '/account/usage', icon: renderIcon(BarChart3) },
-  { label: '我的明细', key: '/account/records', icon: renderIcon(List) },
-  { label: 'API 密钥', key: '/account/keys', icon: renderIcon(KeyRound) },
-  { label: '可用模型', key: '/account/models', icon: renderIcon(Cpu) },
-  { label: '账户设置', key: '/account/settings', icon: renderIcon(UserRound) },
-]
+const accountMenuItems = computed<MenuOption[]>(() => [
+  { label: t('我的用量', 'My Usage'), key: '/account/usage', icon: renderIcon(BarChart3) },
+  { label: t('我的明细', 'My Records'), key: '/account/records', icon: renderIcon(List) },
+  { label: t('API 密钥', 'API Keys'), key: '/account/keys', icon: renderIcon(KeyRound) },
+  { label: t('可用模型', 'Available Models'), key: '/account/models', icon: renderIcon(Cpu) },
+  { label: t('账户设置', 'Account Settings'), key: '/account/settings', icon: renderIcon(UserRound) },
+])
 
 const isAdmin = computed(() => {
   if (currentUser.value) {
@@ -144,8 +151,8 @@ const isAdmin = computed(() => {
   }
   return false
 })
-const roleText = computed(() => (isAdmin.value ? '管理员' : '普通用户'))
-const accountText = computed(() => currentUser.value?.username || '当前账号')
+const roleText = computed(() => (isAdmin.value ? t('管理员', 'Admin') : t('普通用户', 'User')))
+const accountText = computed(() => currentUser.value?.username || t('当前账号', 'Current account'))
 
 function formatAppVersion(value: string | undefined): string {
   const version = value?.trim()
@@ -165,33 +172,33 @@ const menuOptions = computed<MenuOption[]>(() => {
   if (isAdmin.value) {
     groups.push({
       type: 'group',
-      label: '统计中心',
+      label: t('统计中心', 'Analytics'),
       key: 'admin-group',
       icon: renderIcon(Shield),
-      children: adminMenuItems,
+      children: adminMenuItems.value,
     })
     groups.push({
       type: 'group',
-      label: '账号巡检',
+      label: t('账号巡检', 'Account Inspection'),
       key: 'account-inspection-group',
       icon: renderIcon(Activity),
-      children: accountInspectionMenuItems,
+      children: accountInspectionMenuItems.value,
     })
   }
   groups.push({
     type: 'group',
-    label: '我的账户',
+    label: t('我的账户', 'My Account'),
     key: 'account-group',
     icon: renderIcon(UserRound),
-    children: accountMenuItems,
+    children: accountMenuItems.value,
   })
   return groups
 })
 
 const leafMenuOptions = computed(() =>
   isAdmin.value
-    ? [...adminMenuItems, ...accountInspectionMenuItems, ...accountMenuItems]
-    : accountMenuItems,
+    ? [...adminMenuItems.value, ...accountInspectionMenuItems.value, ...accountMenuItems.value]
+    : accountMenuItems.value,
 )
 
 const selectedKey = computed(() => {
@@ -260,7 +267,7 @@ async function handleLogout() {
   await logout()
   setCurrentUser(null)
   hasLoadedUser.value = true
-  message.success('已退出登录')
+  message.success(t('已退出登录', 'Signed out'))
   await router.push('/login')
 }
 
@@ -282,6 +289,11 @@ const themeIcon = computed(() => {
   }
   return isDark.value ? Moon : Sun
 })
+
+const languageLabel = computed(() => (language.value === 'zh' ? 'EN' : 'CN'))
+const languageAriaLabel = computed(() => t('切换语言', 'Switch language'))
+const themeAriaLabel = computed(() => t('切换主题', 'Switch theme'))
+const logoutAriaLabel = computed(() => t('退出登录', 'Sign out'))
 </script>
 
 <template>
@@ -316,7 +328,7 @@ const themeIcon = computed(() => {
           :href="repositoryUrl"
           target="_blank"
           rel="noreferrer"
-          aria-label="在 GitHub 查看 CPA-Helper"
+          :aria-label="t('在 GitHub 查看 CPA-Helper', 'View CPA-Helper on GitHub')"
         >
           <NIcon :component="Github" :size="20" />
           <span class="sider-version-text">{{ appVersion }}</span>
@@ -324,23 +336,34 @@ const themeIcon = computed(() => {
         <div class="sider-actions">
           <NTooltip trigger="hover">
             <template #trigger>
-              <NButton quaternary circle :aria-label="'切换主题'" @click="cycleTheme">
+              <NButton quaternary circle :aria-label="languageAriaLabel" @click="toggleLanguage">
+                <template #icon>
+                  <NIcon :component="Languages" />
+                </template>
+                <span class="sr-only">{{ languageLabel }}</span>
+              </NButton>
+            </template>
+            {{ language === 'zh' ? 'English' : '中文' }}
+          </NTooltip>
+          <NTooltip trigger="hover">
+            <template #trigger>
+              <NButton quaternary circle :aria-label="themeAriaLabel" @click="cycleTheme">
                 <template #icon>
                   <NIcon :component="themeIcon" />
                 </template>
               </NButton>
             </template>
-            主题
+            {{ t('主题', 'Theme') }}
           </NTooltip>
           <NTooltip trigger="hover">
             <template #trigger>
-              <NButton quaternary circle :aria-label="'退出登录'" @click="handleLogout">
+              <NButton quaternary circle :aria-label="logoutAriaLabel" @click="handleLogout">
                 <template #icon>
                   <NIcon :component="LogOut" />
                 </template>
               </NButton>
             </template>
-            退出
+            {{ t('退出', 'Sign out') }}
           </NTooltip>
         </div>
       </div>
@@ -348,12 +371,12 @@ const themeIcon = computed(() => {
 
     <NLayout class="app-main">
       <NLayoutHeader class="mobile-header" bordered>
-        <NButton quaternary circle :aria-label="'打开导航'" @click="drawerOpen = true">
+        <NButton quaternary circle :aria-label="t('打开导航', 'Open navigation')" @click="drawerOpen = true">
           <template #icon>
             <NIcon :component="Menu" />
           </template>
         </NButton>
-        <div class="mobile-brand" aria-label="CPA-Helper 账号信息">
+        <div class="mobile-brand" :aria-label="t('CPA-Helper 账号信息', 'CPA-Helper account info')">
           <img class="mobile-brand-logo" :src="logoUrl" alt="" aria-hidden="true">
           <div class="mobile-brand-copy">
             <div class="mobile-title-row">
@@ -363,11 +386,19 @@ const themeIcon = computed(() => {
             <span>{{ accountText }} · {{ roleText }}</span>
           </div>
         </div>
-        <NButton quaternary circle :aria-label="'切换主题'" @click="toggleTheme">
-          <template #icon>
-            <NIcon :component="themeIcon" />
-          </template>
-        </NButton>
+        <div class="mobile-actions">
+          <NButton quaternary circle :aria-label="languageAriaLabel" @click="toggleLanguage">
+            <template #icon>
+              <NIcon :component="Languages" />
+            </template>
+            <span class="sr-only">{{ languageLabel }}</span>
+          </NButton>
+          <NButton quaternary circle :aria-label="themeAriaLabel" @click="toggleTheme">
+            <template #icon>
+              <NIcon :component="themeIcon" />
+            </template>
+          </NButton>
+        </div>
       </NLayoutHeader>
       <NLayoutContent
         class="content"
@@ -400,17 +431,23 @@ const themeIcon = computed(() => {
       <NDrawerContent :title="`CPA-Helper · ${appVersion}`" body-content-style="padding: 0;">
         <NMenu :value="selectedKey" :options="menuOptions" @update:value="handleMenuUpdate" />
         <div class="drawer-actions">
+          <NButton secondary @click="toggleLanguage">
+            <template #icon>
+              <NIcon :component="Languages" />
+            </template>
+            {{ language === 'zh' ? 'English' : '中文' }}
+          </NButton>
           <NButton secondary @click="cycleTheme">
             <template #icon>
               <NIcon :component="themeIcon" />
             </template>
-            主题
+            {{ t('主题', 'Theme') }}
           </NButton>
           <NButton secondary @click="handleLogout">
             <template #icon>
               <NIcon :component="LogOut" />
             </template>
-            退出
+            {{ t('退出', 'Sign out') }}
           </NButton>
         </div>
       </NDrawerContent>
@@ -676,6 +713,18 @@ const themeIcon = computed(() => {
   box-shadow: var(--cpa-shadow-card), var(--cpa-shadow-hairline);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
 .app-main {
   display: flex;
   flex-direction: column;
@@ -849,7 +898,7 @@ const themeIcon = computed(() => {
 .mobile-header {
   display: none;
   align-items: center;
-  grid-template-columns: 42px minmax(0, 1fr) 42px;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
   gap: 8px;
   height: 56px;
   padding: 0 10px;
@@ -861,6 +910,12 @@ const themeIcon = computed(() => {
 .mobile-header :deep(.n-button) {
   width: 38px;
   height: 38px;
+}
+
+.mobile-actions {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
 }
 
 .mobile-brand {
@@ -921,7 +976,7 @@ const themeIcon = computed(() => {
 
 .drawer-actions {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
   padding: 14px;
 }

--- a/frontend/src/features/api-keys/views/ApiKeysView.vue
+++ b/frontend/src/features/api-keys/views/ApiKeysView.vue
@@ -50,11 +50,13 @@ import type {
   UserApiKeySummary,
   UserQuotaStatus,
 } from '@/shared/types/api'
+import { useI18n } from '@/shared/i18n'
 import { copyToClipboard } from '@/shared/utils/clipboard'
 import { formatCompact, formatDateTime, formatInteger, formatUsd } from '@/shared/utils/format'
 
 const message = useMessage()
 const dialog = useDialog()
+const { copiedText, currentLanguage, errorText, t } = useI18n()
 const isLoading = ref(false)
 const isSaving = ref(false)
 const apiKeys = ref<UserApiKeySummary[]>([])
@@ -67,7 +69,11 @@ const requestTestVisible = ref(false)
 const requestTestApiKey = ref<UserApiKeySummary | null>(null)
 const requestEndpoint = ref<ModelRequestEndpoint>('chat_completions')
 const requestTestModel = ref<string | null>(null)
-const requestTestMessage = ref('请用一句中文回复：连接测试成功。')
+const requestTestMessageDefaults = {
+  zh: '请用一句中文回复：连接测试成功。',
+  en: 'Reply in one English sentence: connection test succeeded.',
+} as const
+const requestTestMessage = ref(requestTestMessageDefaults[currentLanguage.value])
 const requestTestResult = ref<ModelRequestTestResponse | null>(null)
 const requestTestError = ref<string | null>(null)
 const isAvailableModelsLoading = ref(false)
@@ -78,7 +84,7 @@ const generatedApiKey = ref<string | null>(null)
 const generatedApiKeyHash = ref<string | null>(null)
 const visibleApiKeyHashes = ref<Set<string>>(new Set())
 
-const requestLoadingText = '加载中'
+const requestLoadingText = computed(() => t('加载中', 'Loading'))
 
 interface RequestEndpointOption {
   label: string
@@ -87,28 +93,28 @@ interface RequestEndpointOption {
   urlLabel: string
 }
 
-const chatCompletionsEndpointOption: RequestEndpointOption = {
-  label: 'Chat Completions',
+const chatCompletionsEndpointOption = computed<RequestEndpointOption>(() => ({
+  label: t('聊天补全', 'Chat Completions'),
   value: 'chat_completions',
   path: '/chat/completions',
-  urlLabel: 'Chat Completions URL',
-}
+  urlLabel: t('聊天补全 URL', 'Chat Completions URL'),
+}))
 
-const requestEndpointOptions: RequestEndpointOption[] = [
-  chatCompletionsEndpointOption,
+const requestEndpointOptions = computed<RequestEndpointOption[]>(() => [
+  chatCompletionsEndpointOption.value,
   {
-    label: 'Responses',
+    label: t('Responses 响应', 'Responses'),
     value: 'responses',
     path: '/responses',
-    urlLabel: 'Responses URL',
+    urlLabel: t('Responses 响应 URL', 'Responses URL'),
   },
   {
-    label: 'Claude Messages',
+    label: t('Claude 消息', 'Claude Messages'),
     value: 'claude_messages',
     path: '/messages',
-    urlLabel: 'Claude Messages URL',
+    urlLabel: t('Claude 消息 URL', 'Claude Messages URL'),
   },
-]
+])
 
 interface ApiKeyMetricCard {
   key: string
@@ -129,39 +135,39 @@ const apiKeyMetrics = computed<ApiKeyMetricCard[]>(() => {
   return [
     {
       key: 'keys',
-      label: 'API 密钥',
+      label: t('API 密钥', 'API keys'),
       value: formatInteger(apiKeys.value.length),
-      footnote: '当前账号',
+      footnote: t('当前账号', 'Current account'),
       tone: 'teal',
       icon: KeyRound,
     },
     {
       key: 'requests',
-      label: '今日请求',
+      label: t('今日请求', 'Requests today'),
       value: formatInteger(todayRequests),
-      footnote: `失败 ${formatInteger(failedToday)}`,
+      footnote: t(`失败 ${formatInteger(failedToday)}`, `${formatInteger(failedToday)} failed`),
       tone: 'blue',
       icon: Activity,
     },
     {
       key: 'tokens',
-      label: '今日 Token',
+      label: t('今日 Token', 'Tokens today'),
       value: formatCompact(todayTokens),
-      footnote: '当前账号用量',
+      footnote: t('当前账号用量', 'Current account usage'),
       tone: 'purple',
       icon: Layers3,
     },
     {
       key: 'cost',
-      label: '今日费用',
+      label: t('今日费用', 'Cost today'),
       value: formatUsd(todayCost),
-      footnote: '按现价估算',
+      footnote: t('按现价估算', 'Estimated at current prices'),
       tone: 'green',
       icon: CircleDollarSign,
     },
     {
       key: 'quota',
-      label: '可用余额',
+      label: t('可用余额', 'Available balance'),
       value: quotaValueText(quota),
       footnote: quotaFootnote(quota),
       tone: quota?.paused ? 'purple' : 'green',
@@ -172,21 +178,21 @@ const apiKeyMetrics = computed<ApiKeyMetricCard[]>(() => {
 
 const canCreateApiKey = computed(() => quotaStatus.value?.can_create_keys ?? true)
 
-const requestBaseURL = computed(() => modelRequestGuide.value?.openai_base_url ?? requestLoadingText)
+const requestBaseURL = computed(() => modelRequestGuide.value?.openai_base_url ?? requestLoadingText.value)
 const requestEndpointMeta = computed(
   () =>
-    requestEndpointOptions.find((option) => option.value === requestEndpoint.value) ??
-    chatCompletionsEndpointOption,
+    requestEndpointOptions.value.find((option) => option.value === requestEndpoint.value) ??
+    chatCompletionsEndpointOption.value,
 )
 const requestEndpointURL = computed(() => {
   const baseURL = modelRequestGuide.value?.openai_base_url
   if (!baseURL) {
-    return requestLoadingText
+    return requestLoadingText.value
   }
   return `${baseURL.replace(/\/$/, '')}${requestEndpointMeta.value.path}`
 })
 const requestEndpointURLLabel = computed(() => requestEndpointMeta.value.urlLabel)
-const requestTestApiKeyText = computed(() => requestTestApiKey.value?.api_key || '<你的 API KEY>')
+const requestTestApiKeyText = computed(() => requestTestApiKey.value?.api_key || t('<你的 API KEY>', '<your API key>'))
 const requestHeaderLines = computed(() => {
   if (requestEndpoint.value === 'claude_messages') {
     return [`x-api-key: ${requestTestApiKeyText.value}`, 'anthropic-version: 2023-06-01']
@@ -196,11 +202,11 @@ const requestHeaderLines = computed(() => {
 const requestHeadersText = computed(() => requestHeaderLines.value.join('\n'))
 const sampleRequest = computed(() => {
   const targetURL =
-    requestEndpointURL.value === requestLoadingText
+    requestEndpointURL.value === requestLoadingText.value
       ? `<${requestEndpointURLLabel.value}>`
       : requestEndpointURL.value
-  const model = requestTestModel.value || '<模型名>'
-  const content = requestTestMessage.value.trim() || '你好'
+  const model = requestTestModel.value || t('<模型名>', '<model name>')
+  const content = requestTestMessage.value.trim() || t('你好', 'Hello')
   const body = requestBodyForEndpoint(requestEndpoint.value, model, content)
   return [
     `curl ${targetURL} \\`,
@@ -222,7 +228,7 @@ const requestTestModelOptions = computed(() => {
 })
 const requestTestReplyText = computed(() => {
   const reply = requestTestResult.value?.reply?.trim()
-  return reply || '模型返回成功，但没有可展示文本。'
+  return reply || t('模型返回成功，但没有可展示文本。', 'The model returned successfully, but there is no displayable text.')
 })
 const requestTestUsageText = computed(() => {
   const usage = requestTestResult.value?.usage
@@ -234,13 +240,13 @@ const requestTestUsageText = computed(() => {
   const total = numberFromUsage(usage.total_tokens)
   const parts: string[] = []
   if (input !== null) {
-    parts.push(`输入 ${formatInteger(input)}`)
+    parts.push(t(`输入 ${formatInteger(input)}`, `Input ${formatInteger(input)}`))
   }
   if (output !== null) {
-    parts.push(`输出 ${formatInteger(output)}`)
+    parts.push(t(`输出 ${formatInteger(output)}`, `Output ${formatInteger(output)}`))
   }
   if (total !== null) {
-    parts.push(`总计 ${formatInteger(total)}`)
+    parts.push(t(`总计 ${formatInteger(total)}`, `Total ${formatInteger(total)}`))
   }
   return parts.join(' / ')
 })
@@ -248,6 +254,13 @@ const requestTestUsageText = computed(() => {
 watch(requestEndpoint, () => {
   requestTestResult.value = null
   requestTestError.value = null
+})
+
+watch(currentLanguage, (language, previousLanguage) => {
+  const previousDefault = requestTestMessageDefaults[previousLanguage]
+  if (requestTestMessage.value === previousDefault) {
+    requestTestMessage.value = requestTestMessageDefaults[language]
+  }
 })
 
 function requestBodyForEndpoint(
@@ -282,31 +295,37 @@ function quoteForCurl(value: string): string {
 
 function quotaValueText(quota: UserQuotaStatus | null): string {
   if (!quota) {
-    return '加载中'
+    return t('加载中', 'Loading')
   }
   if (quota.unlimited) {
-    return '每月余额 无限制'
+    return t('每月余额 无限制', 'Monthly balance unlimited')
   }
-  return `每月余额 ${formatUsd(quota.monthly_remaining_usd ?? 0)}`
+  return t(
+    `每月余额 ${formatUsd(quota.monthly_remaining_usd ?? 0)}`,
+    `Monthly balance ${formatUsd(quota.monthly_remaining_usd ?? 0)}`,
+  )
 }
 
 function quotaFootnote(quota: UserQuotaStatus | null): string {
   if (!quota) {
-    return '额度加载中'
+    return t('额度加载中', 'Quota loading')
   }
   if (quota.unlimited) {
-    return '不限时余额 无限制'
+    return t('不限时余额 无限制', 'Lifetime balance unlimited')
   }
-  const lifetimeText = `不限时余额 ${formatUsd(quota.lifetime_remaining_usd ?? 0)}`
+  const lifetimeText = t(
+    `不限时余额 ${formatUsd(quota.lifetime_remaining_usd ?? 0)}`,
+    `Lifetime balance ${formatUsd(quota.lifetime_remaining_usd ?? 0)}`,
+  )
   const notes: string[] = []
   if (quota.sync_error) {
-    notes.push('Key 同步异常')
+    notes.push(t('Key 同步异常', 'Key sync error'))
   }
   if (quota.unpriced_records > 0) {
-    notes.push(`未定价 ${formatInteger(quota.unpriced_records)} 条`)
+    notes.push(t(`未定价 ${formatInteger(quota.unpriced_records)} 条`, `${formatInteger(quota.unpriced_records)} unpriced records`))
   }
   if (quota.paused) {
-    notes.push('Key 已因余额暂停')
+    notes.push(t('Key 已因余额暂停', 'Key paused due to balance'))
   }
   return notes.length > 0 ? `${lifetimeText} · ${notes.join(' · ')}` : lifetimeText
 }
@@ -343,7 +362,7 @@ function displayedApiKey(row: UserApiKeySummary): string {
 
 function maskDisplayedApiKey(apiKey: string | null | undefined): string {
   if (!apiKey) {
-    return '未知'
+    return t('未知', 'Unknown')
   }
   if (apiKey.length <= 12) {
     return `${apiKey.slice(0, 3)}${'*'.repeat(Math.max(apiKey.length - 3, 0))}`
@@ -357,7 +376,7 @@ function maskDisplayedApiKey(apiKey: string | null | undefined): string {
 function renderMaskedKeyTitle() {
   return h('span', { class: 'api-key-title' }, [
     h(NIcon, { class: 'api-key-mask-icon', component: EyeOff }),
-    h('span', '密钥（点击复制）'),
+    h('span', t('密钥（点击复制）', 'Key (click to copy)')),
   ])
 }
 
@@ -367,7 +386,7 @@ function isApiKeyVisible(row: UserApiKeySummary): boolean {
 
 function toggleApiKeyVisibility(row: UserApiKeySummary) {
   if (!row.api_key) {
-    message.info('当前没有完整密钥可显示')
+    message.info(t('当前没有完整密钥可显示', 'No full key is available to show'))
     return
   }
   const nextVisible = new Set(visibleApiKeyHashes.value)
@@ -382,13 +401,13 @@ function toggleApiKeyVisibility(row: UserApiKeySummary) {
 async function copyApiKey(row: UserApiKeySummary) {
   try {
     if (!row.api_key) {
-      message.info('当前没有完整密钥可复制')
+      message.info(t('当前没有完整密钥可复制', 'No full key is available to copy'))
       return
     }
     await copyToClipboard(row.api_key)
-    message.success('API 密钥已复制')
+    message.success(t('API 密钥已复制', 'API key copied'))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '复制失败')
+    message.error(errorText(error, '复制失败', 'Copy failed'))
   }
 }
 
@@ -398,9 +417,9 @@ async function copyGeneratedApiKey() {
   }
   try {
     await copyToClipboard(generatedApiKey.value)
-    message.success('API 密钥已复制')
+    message.success(t('API 密钥已复制', 'API key copied'))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '复制失败')
+    message.error(errorText(error, '复制失败', 'Copy failed'))
   }
 }
 
@@ -408,7 +427,7 @@ async function loadModelRequestGuide() {
   try {
     modelRequestGuide.value = await getModelRequestGuide()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载请求地址失败')
+    message.error(errorText(error, '加载请求地址失败', 'Failed to load request endpoints'))
   }
 }
 
@@ -418,7 +437,7 @@ async function loadAvailableModelsForTest() {
     availableModels.value = await listAvailableModels()
     ensureRequestTestModel()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载可用模型失败')
+    message.error(errorText(error, '加载可用模型失败', 'Failed to load available models'))
   } finally {
     isAvailableModelsLoading.value = false
   }
@@ -427,6 +446,7 @@ async function loadAvailableModelsForTest() {
 function openRequestTest(row: UserApiKeySummary) {
   requestTestApiKey.value = row
   requestTestModel.value = row.last_model ?? row.models[0] ?? null
+  requestTestMessage.value = requestTestMessageDefaults[currentLanguage.value]
   requestTestResult.value = null
   requestTestError.value = null
   requestTestVisible.value = true
@@ -441,14 +461,14 @@ function openRequestTest(row: UserApiKeySummary) {
 }
 
 async function copyRequestValue(label: string, value: string) {
-  if (!value || value === requestLoadingText) {
+  if (!value || value === requestLoadingText.value) {
     return
   }
   try {
     await copyToClipboard(value)
-    message.success(`${label} 已复制`)
+    message.success(copiedText(label))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '复制失败')
+    message.error(errorText(error, '复制失败', 'Copy failed'))
   }
 }
 
@@ -459,11 +479,11 @@ async function runRequestTest() {
   const currentKey = requestTestApiKey.value
   const model = requestTestModel.value?.trim() ?? ''
   if (!currentKey) {
-    message.error('请选择要测试的 API KEY')
+    message.error(t('请选择要测试的 API KEY', 'Select an API key to test'))
     return
   }
   if (!model) {
-    message.error('请选择测试模型')
+    message.error(t('请选择测试模型', 'Select a test model'))
     return
   }
   isRequestTesting.value = true
@@ -476,9 +496,9 @@ async function runRequestTest() {
       model,
       message: requestTestMessage.value,
     })
-    message.success('请求测试完成')
+    message.success(t('请求测试完成', 'Request test completed'))
   } catch (error) {
-    requestTestError.value = error instanceof Error ? error.message : '请求测试失败'
+    requestTestError.value = errorText(error, '请求测试失败', 'Request test failed')
   } finally {
     isRequestTesting.value = false
   }
@@ -486,7 +506,7 @@ async function runRequestTest() {
 
 function openCreateDialog() {
   if (!canCreateApiKey.value) {
-    message.error('当前账号额度已用尽，API KEY 已暂停')
+    message.error(t('当前账号额度已用尽，API KEY 已暂停', 'This account has exhausted its quota, so API keys are paused'))
     return
   }
   editingApiKeyHash.value = null
@@ -530,7 +550,7 @@ async function refresh() {
       }
     }
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载 API 密钥失败')
+    message.error(errorText(error, '加载 API 密钥失败', 'Failed to load API keys'))
   } finally {
     isLoading.value = false
   }
@@ -542,29 +562,29 @@ async function saveApiKey() {
   }
   const description = apiKeyDescription.value.trim()
   if (!description) {
-    message.error('API KEY 描述不能为空')
+    message.error(t('API KEY 描述不能为空', 'API key description is required'))
     return
   }
   isSaving.value = true
   try {
     if (editingApiKeyHash.value) {
       await updateApiKey(editingApiKeyHash.value, { description })
-      message.success('API 密钥已更新')
+      message.success(t('API 密钥已更新', 'API key updated'))
     } else {
       if (!canCreateApiKey.value) {
-        message.error('当前账号额度已用尽，API KEY 已暂停')
+        message.error(t('当前账号额度已用尽，API KEY 已暂停', 'This account has exhausted its quota, so API keys are paused'))
         return
       }
       const created = await createApiKey({ description })
       generatedApiKey.value = created.api_key ?? null
       generatedApiKeyHash.value = created.api_key_hash
-      message.success('API 密钥已创建并同步到 CPA')
+      message.success(t('API 密钥已创建并同步到 CPA', 'API key created and synced to CPA'))
     }
     editorVisible.value = false
     editingApiKeyHash.value = null
     await refresh()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '保存 API 密钥失败')
+    message.error(errorText(error, '保存 API 密钥失败', 'Failed to save API key'))
   } finally {
     isSaving.value = false
   }
@@ -572,13 +592,16 @@ async function saveApiKey() {
 
 function confirmDelete(row: UserApiKeySummary) {
   dialog.warning({
-    title: '删除 API 密钥',
-    content: `将删除 ${row.description || '未命名'} 对应的密钥，并从 CPA 中移除。`,
-    positiveText: '删除',
-    negativeText: '取消',
+    title: t('删除 API 密钥', 'Delete API key'),
+    content: t(
+      `将删除 ${row.description || '未命名'} 对应的密钥，并从 CPA 中移除。`,
+      `This deletes the key for ${row.description || 'Unnamed'} and removes it from CPA.`,
+    ),
+    positiveText: t('删除', 'Delete'),
+    negativeText: t('取消', 'Cancel'),
     onPositiveClick: async () => {
       await deleteApiKey(row.api_key_hash)
-      message.success('API 密钥已删除')
+      message.success(t('API 密钥已删除', 'API key deleted'))
       if (editingApiKeyHash.value === row.api_key_hash) {
         editorVisible.value = false
         editingApiKeyHash.value = null
@@ -592,7 +615,7 @@ function confirmDelete(row: UserApiKeySummary) {
   })
 }
 
-const columns: DataTableColumns<UserApiKeySummary> = [
+const columns = computed<DataTableColumns<UserApiKeySummary>>(() => [
   {
     title: renderMaskedKeyTitle,
     key: 'api_key',
@@ -607,7 +630,7 @@ const columns: DataTableColumns<UserApiKeySummary> = [
             {
               class: 'api-key-visibility-button',
               disabled: !row.api_key,
-              title: isApiKeyVisible(row) ? '隐藏完整密钥' : '显示完整密钥',
+              title: isApiKeyVisible(row) ? t('隐藏完整密钥', 'Hide full key') : t('显示完整密钥', 'Show full key'),
               type: 'button',
               onClick: () => toggleApiKeyVisibility(row),
             },
@@ -623,7 +646,7 @@ const columns: DataTableColumns<UserApiKeySummary> = [
             {
               class: 'api-key-copy-button',
               type: 'button',
-              title: row.api_key ? '点击复制完整密钥' : '无完整密钥可复制',
+              title: row.api_key ? t('点击复制完整密钥', 'Click to copy full key') : t('无完整密钥可复制', 'No full key available to copy'),
               onClick: () => copyApiKey(row),
             },
             h('span', { class: 'api-key-mask-text' }, displayedApiKey(row)),
@@ -632,13 +655,13 @@ const columns: DataTableColumns<UserApiKeySummary> = [
       ),
   },
   {
-    title: '描述',
+    title: t('描述', 'Description'),
     key: 'description',
     width: 240,
     render: (row) => row.description || '-',
   },
   {
-    title: '创建时间',
+    title: t('创建时间', 'Created at'),
     key: 'created_at',
     width: 180,
     render: (row) => formatDateTime(row.created_at),
@@ -656,23 +679,23 @@ const columns: DataTableColumns<UserApiKeySummary> = [
             { size: 'small', quaternary: true, onClick: () => openRequestTest(row) },
             {
               icon: () => h(NIcon, { component: Send }),
-              default: () => '请求测试',
+              default: () => t('请求测试', 'Request test'),
             },
           ),
           h(
             NButton,
             { size: 'small', quaternary: true, onClick: () => editApiKey(row) },
-            { default: () => '编辑' },
+            { default: () => t('编辑', 'Edit') },
           ),
           h(
             NButton,
             { size: 'small', quaternary: true, type: 'error', onClick: () => confirmDelete(row) },
-            { default: () => '删除' },
+            { default: () => t('删除', 'Delete') },
           ),
         ],
       }),
   },
-]
+])
 
 onMounted(refresh)
 </script>
@@ -681,13 +704,13 @@ onMounted(refresh)
   <section class="page">
     <div class="page-header">
       <div>
-        <h1 class="page-title">API 密钥</h1>
-        <p class="page-subtitle">仅管理当前账号自己的密钥</p>
+        <h1 class="page-title">{{ t('API 密钥', 'API keys') }}</h1>
+        <p class="page-subtitle">{{ t('仅管理当前账号自己的密钥', 'Manage only keys for the current account') }}</p>
       </div>
       <NSpace>
-        <NButton secondary :loading="isLoading" @click="refresh">刷新</NButton>
+        <NButton secondary :loading="isLoading" @click="refresh">{{ t('刷新', 'Refresh') }}</NButton>
         <NButton type="primary" :disabled="!canCreateApiKey" @click="openCreateDialog">
-          新建 API 密钥
+          {{ t('新建 API 密钥', 'New API key') }}
         </NButton>
       </NSpace>
     </div>
@@ -705,27 +728,25 @@ onMounted(refresh)
 
     <section class="panel api-key-panel-shell">
       <div class="panel-inner api-key-panel">
-        <NAlert type="warning" :bordered="false" title="请求链路说明">
-          Agent 发起的模型请求仍需 Agent 直接发送到 CPA，CPA-Helper 不代理或中转这些请求；仅调用 CPA
-          的 usage 队列、API KEY 创建与删除、凭证管理等接口，用于用量查看、密钥创建和凭证维护。API
-          密钥拥有当前账号的完整权限，请妥善保管。
+        <NAlert type="warning" :bordered="false" :title="t('请求链路说明', 'Request path note')">
+          {{ t('Agent 发起的模型请求仍需 Agent 直接发送到 CPA，CPA-Helper 不代理或中转这些请求；仅调用 CPA 的 usage 队列、API KEY 创建与删除、凭证管理等接口，用于用量查看、密钥创建和凭证维护。API 密钥拥有当前账号的完整权限，请妥善保管。', 'Model requests from agents must still be sent directly to CPA by the agent. CPA-Helper does not proxy or relay these requests. It only calls CPA usage queue, API key create/delete, and credential management APIs for usage views, key creation, and credential maintenance. API keys have full permissions for the current account; store them carefully.') }}
         </NAlert>
 
-        <NAlert v-if="quotaStatus?.paused" type="error" :bordered="false" title="额度已用尽">
-          当前账号 API KEY 已从 CPA 暂停。补充额度或进入新月份恢复月额度后，系统会自动恢复可用 Key。
+        <NAlert v-if="quotaStatus?.paused" type="error" :bordered="false" :title="t('额度已用尽', 'Quota exhausted')">
+          {{ t('当前账号 API KEY 已从 CPA 暂停。补充额度或进入新月份恢复月额度后，系统会自动恢复可用 Key。', 'API keys for this account are paused in CPA. After quota is added or monthly quota resets, available keys are restored automatically.') }}
         </NAlert>
         <NAlert v-else-if="quotaStatus?.unpriced_records" type="warning" :bordered="false">
-          当前账号存在 {{ formatInteger(quotaStatus.unpriced_records) }} 条未定价用量，未计入额度扣减。
+          {{ t(`当前账号存在 ${formatInteger(quotaStatus.unpriced_records)} 条未定价用量，未计入额度扣减。`, `This account has ${formatInteger(quotaStatus.unpriced_records)} unpriced usage records that are not deducted from quota.`) }}
         </NAlert>
 
         <div v-if="generatedApiKey" class="generated-key-box">
           <div class="generated-key-main">
-            <div class="generated-key-title">新创建的密钥</div>
+            <div class="generated-key-title">{{ t('新创建的密钥', 'Newly created key') }}</div>
             <div class="generated-key-value">{{ generatedApiKey }}</div>
           </div>
           <NSpace>
-            <NButton secondary @click="copyGeneratedApiKey">复制</NButton>
-            <NButton tertiary @click="closeGeneratedApiKey">关闭</NButton>
+            <NButton secondary @click="copyGeneratedApiKey">{{ t('复制', 'Copy') }}</NButton>
+            <NButton tertiary @click="closeGeneratedApiKey">{{ t('关闭', 'Close') }}</NButton>
           </NSpace>
         </div>
 
@@ -747,27 +768,27 @@ onMounted(refresh)
       preset="card"
       :mask-closable="false"
       :closable="false"
-      :title="editingApiKeyHash ? '编辑 API 密钥' : '新建 API 密钥'"
+      :title="editingApiKeyHash ? t('编辑 API 密钥', 'Edit API key') : t('新建 API 密钥', 'New API key')"
       :style="{ width: 'min(520px, calc(100vw - 32px))' }"
     >
       <NForm label-placement="top">
-        <NFormItem label="API KEY 描述">
+        <NFormItem :label="t('API KEY 描述', 'API key description')">
           <NInput
             v-model:value="apiKeyDescription"
             :disabled="isSaving"
-            placeholder="例如：VSCode"
+            :placeholder="t('例如：VSCode', 'Example: VSCode')"
             @keyup.enter="saveApiKey"
           />
         </NFormItem>
         <div class="modal-actions">
-          <NButton secondary :disabled="isSaving" @click="editorVisible = false">取消</NButton>
+          <NButton secondary :disabled="isSaving" @click="editorVisible = false">{{ t('取消', 'Cancel') }}</NButton>
           <NButton
             type="primary"
             :loading="isSaving"
             :disabled="isSaving || (!editingApiKeyHash && !canCreateApiKey)"
             @click="saveApiKey"
           >
-            {{ editingApiKeyHash ? '保存' : '创建' }}
+            {{ editingApiKeyHash ? t('保存', 'Save') : t('创建', 'Create') }}
           </NButton>
         </div>
       </NForm>
@@ -776,16 +797,16 @@ onMounted(refresh)
     <NModal
       v-model:show="requestTestVisible"
       preset="card"
-      title="请求测试"
+      :title="t('请求测试', 'Request test')"
       :style="{ width: 'min(760px, calc(100vw - 32px))' }"
     >
       <div class="request-test">
         <NAlert type="info" :bordered="false">
-          这里提供当前 API KEY 的请求说明，也可以直接选择模型发起一次真实测试。
+          {{ t('这里提供当前 API KEY 的请求说明，也可以直接选择模型发起一次真实测试。', 'This shows request instructions for the current API key. You can also choose a model to run a real test request.') }}
         </NAlert>
 
         <div class="request-endpoint-switch">
-          <span class="request-endpoint-label">请求格式</span>
+          <span class="request-endpoint-label">{{ t('请求格式', 'Request format') }}</span>
           <NRadioGroup v-model:value="requestEndpoint" size="small">
             <NRadioButton
               v-for="option in requestEndpointOptions"
@@ -800,14 +821,14 @@ onMounted(refresh)
         <div class="request-guide-list">
           <div class="request-guide-row">
             <div>
-              <div class="request-guide-label">Base URL</div>
+              <div class="request-guide-label">{{ t('基础 URL', 'Base URL') }}</div>
               <code class="request-guide-value">{{ requestBaseURL }}</code>
             </div>
-            <NButton size="small" secondary @click="copyRequestValue('Base URL', requestBaseURL)">
+            <NButton size="small" secondary @click="copyRequestValue(t('基础 URL', 'Base URL'), requestBaseURL)">
               <template #icon>
                 <NIcon :component="Copy" />
               </template>
-              复制
+              {{ t('复制', 'Copy') }}
             </NButton>
           </div>
           <div class="request-guide-row">
@@ -815,59 +836,59 @@ onMounted(refresh)
               <div class="request-guide-label">{{ requestEndpointURLLabel }}</div>
               <code class="request-guide-value">{{ requestEndpointURL }}</code>
             </div>
-            <NButton size="small" secondary @click="copyRequestValue('请求 URL', requestEndpointURL)">
+            <NButton size="small" secondary @click="copyRequestValue(t('请求 URL', 'Request URL'), requestEndpointURL)">
               <template #icon>
                 <NIcon :component="Copy" />
               </template>
-              复制
+              {{ t('复制', 'Copy') }}
             </NButton>
           </div>
           <div class="request-guide-row">
             <div>
-              <div class="request-guide-label">Header</div>
+              <div class="request-guide-label">{{ t('请求 Header', 'Request headers') }}</div>
               <code class="request-guide-value request-guide-value-multiline">{{ requestHeadersText }}</code>
             </div>
-            <NButton size="small" secondary @click="copyRequestValue('Header', requestHeadersText)">
+            <NButton size="small" secondary @click="copyRequestValue(t('请求 Header', 'Request headers'), requestHeadersText)">
               <template #icon>
                 <NIcon :component="Copy" />
               </template>
-              复制
+              {{ t('复制', 'Copy') }}
             </NButton>
           </div>
         </div>
 
         <div class="request-example">
           <div class="request-example-head">
-            <span>curl 示例</span>
-            <NButton size="small" secondary @click="copyRequestValue('curl 示例', sampleRequest)">
+            <span>{{ t('curl 示例', 'curl example') }}</span>
+            <NButton size="small" secondary @click="copyRequestValue(t('curl 示例', 'curl example'), sampleRequest)">
               <template #icon>
                 <NIcon :component="Copy" />
               </template>
-              复制示例
+              {{ t('复制示例', 'Copy example') }}
             </NButton>
           </div>
           <pre>{{ sampleRequest }}</pre>
         </div>
 
-        <div class="request-test-section-title">请求测试</div>
+        <div class="request-test-section-title">{{ t('请求测试', 'Request test') }}</div>
 
         <NForm label-placement="top" class="request-test-form">
-          <NFormItem label="测试模型">
+          <NFormItem :label="t('测试模型', 'Test model')">
             <NSelect
               v-model:value="requestTestModel"
               filterable
               clearable
               :loading="isAvailableModelsLoading"
               :options="requestTestModelOptions"
-              placeholder="选择当前 Key 可用的模型"
+              :placeholder="t('选择当前 Key 可用的模型', 'Select a model available to this key')"
             />
           </NFormItem>
-          <NFormItem label="测试消息">
+          <NFormItem :label="t('测试消息', 'Test message')">
             <NInput
               v-model:value="requestTestMessage"
               type="textarea"
               :autosize="{ minRows: 3, maxRows: 5 }"
-              placeholder="输入要发送给模型的测试消息"
+              :placeholder="t('输入要发送给模型的测试消息', 'Enter the test message to send to the model')"
             />
           </NFormItem>
         </NForm>
@@ -877,12 +898,12 @@ onMounted(refresh)
           type="warning"
           :bordered="false"
         >
-          当前 Key 暂未查询到可选模型，可以先刷新模型列表，或到「可用模型」页面检查 Key 是否可用。
+          {{ t('当前 Key 暂未查询到可选模型，可以先刷新模型列表，或到「可用模型」页面检查 Key 是否可用。', 'No selectable models were found for this key. Refresh the model list, or check whether the key is available on the Available models page.') }}
         </NAlert>
 
         <div class="modal-actions request-test-actions">
           <NButton secondary :loading="isAvailableModelsLoading" @click="loadAvailableModelsForTest">
-            刷新模型
+            {{ t('刷新模型', 'Refresh models') }}
           </NButton>
           <NButton
             type="primary"
@@ -893,7 +914,7 @@ onMounted(refresh)
             <template #icon>
               <NIcon :component="Send" />
             </template>
-            发送测试
+            {{ t('发送测试', 'Send test') }}
           </NButton>
         </div>
 
@@ -903,7 +924,7 @@ onMounted(refresh)
 
         <div v-if="requestTestResult" class="request-test-result">
           <div class="request-test-result-head">
-            <span>模型回复</span>
+            <span>{{ t('模型回复', 'Model reply') }}</span>
             <span>
               HTTP {{ requestTestResult.status_code }} · {{ requestTestResult.duration_ms }}ms
               <template v-if="requestTestUsageText"> · {{ requestTestUsageText }}</template>

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/shared/api/apiClient'
+import { localize } from '@/shared/i18n'
 import type {
   AuthUser,
   ChangeCredentialsPayload,
@@ -22,7 +23,7 @@ export function isAuthUser(value: unknown): value is AuthUser {
 
 function toAuthUser(value: unknown): AuthUser {
   if (!isAuthUser(value)) {
-    throw new Error('登录状态缺少角色信息，请重启后端服务后重新登录')
+    throw new Error(localize('登录状态缺少角色信息，请重启后端服务后重新登录', 'Your session is missing role information. Restart the backend and sign in again.'))
   }
   return value
 }

--- a/frontend/src/features/auth/views/ChangeCredentialsView.vue
+++ b/frontend/src/features/auth/views/ChangeCredentialsView.vue
@@ -5,10 +5,12 @@ import { NAlert, NButton, NCard, NForm, NFormItem, NInput, useMessage } from 'na
 
 import { changeCredentials, getMe } from '@/features/auth/api/authApi'
 import { setCurrentUser } from '@/features/auth/state/currentUser'
+import { useI18n } from '@/shared/i18n'
 import { logoUrl } from '@/shared/utils/assets'
 
 const router = useRouter()
 const message = useMessage()
+const { errorText, t } = useI18n()
 const isLoading = ref(false)
 const errorMessage = ref<string | null>(null)
 const form = reactive({
@@ -35,10 +37,10 @@ async function handleSubmit() {
       current_password: form.current_password || undefined,
     })
     setCurrentUser(user)
-    message.success('密码已更新')
+    message.success(t('密码已更新', 'Password updated'))
     await router.push(user.is_admin ? '/admin/usage' : '/account/usage')
   } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : '更新失败'
+    errorMessage.value = errorText(error, '更新失败', 'Update failed')
   } finally {
     isLoading.value = false
   }
@@ -54,15 +56,15 @@ async function handleSubmit() {
       </div>
     </section>
 
-    <section class="auth-content" aria-label="修改密码区域">
+    <section class="auth-content" :aria-label="t('修改密码区域', 'Change password area')">
       <div class="brand-mark">
         <img :src="logoUrl" alt="">
       </div>
 
       <NCard class="auth-card" :bordered="true">
         <div class="auth-heading">
-          <h1>修改密码</h1>
-          <p>首次登录后需要完成密码更新</p>
+          <h1>{{ t('修改密码', 'Change password') }}</h1>
+          <p>{{ t('首次登录后需要完成密码更新', 'Update your password after first sign-in') }}</p>
         </div>
 
         <NAlert v-if="errorMessage" type="error" :bordered="false" class="auth-alert">
@@ -70,10 +72,10 @@ async function handleSubmit() {
         </NAlert>
 
         <NForm :model="form" label-placement="top" @submit.prevent="handleSubmit">
-          <NFormItem label="账号" path="username">
+          <NFormItem :label="t('账号', 'Account')" path="username">
             <NInput v-model:value="form.username" autocomplete="username" disabled />
           </NFormItem>
-          <NFormItem label="新密码" path="password">
+          <NFormItem :label="t('新密码', 'New password')" path="password">
             <NInput
               v-model:value="form.password"
               type="password"
@@ -81,7 +83,7 @@ async function handleSubmit() {
               autocomplete="new-password"
             />
           </NFormItem>
-          <NFormItem label="当前密码" path="current_password">
+          <NFormItem :label="t('当前密码', 'Current password')" path="current_password">
             <NInput
               v-model:value="form.current_password"
               type="password"
@@ -91,7 +93,7 @@ async function handleSubmit() {
             />
           </NFormItem>
           <NButton type="primary" block attr-type="submit" :loading="isLoading">
-            保存
+            {{ t('保存', 'Save') }}
           </NButton>
         </NForm>
       </NCard>

--- a/frontend/src/features/auth/views/LoginView.vue
+++ b/frontend/src/features/auth/views/LoginView.vue
@@ -5,11 +5,13 @@ import { NAlert, NButton, NCard, NForm, NFormItem, NInput, useMessage } from 'na
 
 import { getSetupState, login, setupFirstAdmin } from '@/features/auth/api/authApi'
 import { setCurrentUser } from '@/features/auth/state/currentUser'
+import { useI18n } from '@/shared/i18n'
 import { logoUrl } from '@/shared/utils/assets'
 
 const route = useRoute()
 const router = useRouter()
 const message = useMessage()
+const { errorText, t } = useI18n()
 const isLoading = ref(false)
 const isSetupLoading = ref(true)
 const setupRequired = ref(false)
@@ -19,18 +21,18 @@ const form = reactive({
   password: '',
   nickname: '',
 })
-const headingTitle = computed(() => (setupRequired.value ? '创建首个管理员账号' : 'CPA-Helper'))
+const headingTitle = computed(() => (setupRequired.value ? t('创建首个管理员账号', 'Create first admin account') : 'CPA-Helper'))
 const headingSubtitle = computed(() =>
-  setupRequired.value ? '首次使用前需要先录入管理员账号' : '本地 AI 用量管理控制台',
+  setupRequired.value ? t('首次使用前需要先录入管理员账号', 'Create an admin account before first use') : t('本地 AI 用量管理控制台', 'Local AI usage management console'),
 )
-const submitText = computed(() => (setupRequired.value ? '创建并登录' : '登录'))
+const submitText = computed(() => (setupRequired.value ? t('创建并登录', 'Create and sign in') : t('登录', 'Sign in')))
 
 onMounted(async () => {
   try {
     const state = await getSetupState()
     setupRequired.value = state.setup_required
   } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : '初始化状态加载失败'
+    errorMessage.value = errorText(error, '初始化状态加载失败', 'Failed to load setup state')
   } finally {
     isSetupLoading.value = false
   }
@@ -38,7 +40,7 @@ onMounted(async () => {
 
 async function handleSubmit() {
   if (setupRequired.value && !form.nickname.trim()) {
-    message.error('用户昵称不能为空')
+    message.error(t('用户昵称不能为空', 'User nickname is required'))
     return
   }
   isLoading.value = true
@@ -53,17 +55,17 @@ async function handleSubmit() {
       })
       setCurrentUser(user)
       homePath = user.is_admin ? '/admin/usage' : '/account/usage'
-      message.success('管理员账号已创建')
+      message.success(t('管理员账号已创建', 'Admin account created'))
     } else {
       const user = await login({ username: form.username, password: form.password })
       setCurrentUser(user)
       homePath = user.is_admin ? '/admin/usage' : '/account/usage'
-      message.success('登录成功')
+      message.success(t('登录成功', 'Signed in'))
     }
     const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : homePath
     await router.push(redirect)
   } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : '登录失败'
+    errorMessage.value = errorText(error, '登录失败', 'Sign in failed')
   } finally {
     isLoading.value = false
   }
@@ -79,7 +81,7 @@ async function handleSubmit() {
       </div>
     </section>
 
-    <section class="auth-content" aria-label="登录区域">
+    <section class="auth-content" :aria-label="t('登录区域', 'Sign-in area')">
       <div class="brand-mark">
         <img :src="logoUrl" alt="">
       </div>
@@ -95,14 +97,14 @@ async function handleSubmit() {
         </NAlert>
 
         <NAlert v-if="setupRequired" type="warning" :bordered="false" class="auth-alert">
-          账号一旦创建，不允许删除，只允许禁用，请谨慎操作。
+          {{ t('账号一旦创建，不允许删除，只允许禁用，请谨慎操作。', 'Accounts cannot be deleted after creation. They can only be disabled, so proceed carefully.') }}
         </NAlert>
 
         <NForm :model="form" label-placement="top" @submit.prevent="handleSubmit">
-          <NFormItem label="账号" path="username">
+          <NFormItem :label="t('账号', 'Account')" path="username">
             <NInput v-model:value="form.username" autocomplete="username" />
           </NFormItem>
-          <NFormItem label="密码" path="password">
+          <NFormItem :label="t('密码', 'Password')" path="password">
             <NInput
               v-model:value="form.password"
               type="password"
@@ -111,8 +113,8 @@ async function handleSubmit() {
               @keyup.enter="handleSubmit"
             />
           </NFormItem>
-          <NFormItem v-if="setupRequired" label="用户昵称" path="nickname" required>
-            <NInput v-model:value="form.nickname" placeholder="例如：研发用户" />
+          <NFormItem v-if="setupRequired" :label="t('用户昵称', 'User nickname')" path="nickname" required>
+            <NInput v-model:value="form.nickname" :placeholder="t('例如：研发用户', 'Example: Engineering user')" />
           </NFormItem>
           <NButton type="primary" block attr-type="submit" :loading="isLoading || isSetupLoading">
             {{ submitText }}

--- a/frontend/src/features/codex-keeper/views/CodexKeeperInspectionView.vue
+++ b/frontend/src/features/codex-keeper/views/CodexKeeperInspectionView.vue
@@ -43,6 +43,7 @@ import type {
   CodexKeeperSettingsUpdatePayload,
   CodexKeeperStatus,
 } from '@/shared/types/api'
+import { useI18n } from '@/shared/i18n'
 import { copyToClipboard } from '@/shared/utils/clipboard'
 import { formatDateTime, formatInteger } from '@/shared/utils/format'
 
@@ -59,6 +60,7 @@ interface ParsedLogLine {
 }
 
 const message = useMessage()
+const { errorText, keeperStatusText, serverText, t } = useI18n()
 const isLoading = ref(false)
 const isSaving = ref(false)
 const isActing = ref(false)
@@ -72,13 +74,13 @@ const shouldFollowLatestLog = ref(true)
 let statusTimer: number | undefined
 let schedulePreviewTimer: number | undefined
 
-const conditionalRefreshIntervalOptions = [
-  { label: '关闭', value: 0 },
-  { label: '5 秒', value: 5 },
-  { label: '10 秒', value: 10 },
-  { label: '30 秒', value: 30 },
-  { label: '60 秒', value: 60 },
-]
+const conditionalRefreshIntervalOptions = computed(() => [
+  { label: t('关闭', 'Off'), value: 0 },
+  { label: t('5 秒', '5 seconds'), value: 5 },
+  { label: t('10 秒', '10 seconds'), value: 10 },
+  { label: t('30 秒', '30 seconds'), value: 30 },
+  { label: t('60 秒', '60 seconds'), value: 60 },
+])
 
 const form = reactive({
   schedule_cron: '*/30 * * * *',
@@ -145,18 +147,16 @@ const stateType = computed(() => {
 const statusDetailText = computed(() => {
   const detail = status.value?.detail
   if (isDaemonRunning.value && !isRunning.value) {
-    return '自动巡检已开启'
+    return t('自动巡检已开启', 'Automatic inspection is enabled')
   }
   if (!detail) {
-    return '未运行'
+    return t('未运行', 'Not running')
   }
-  return detail
-    .replace(/守护运行中/g, '自动巡检运行中')
-    .replace(/守护进程/g, '后台自动巡检')
-    .replace(/守护任务/g, '自动巡检任务')
-    .replace(/守护已启动/g, '已开始自动巡检')
+  return keeperStatusText(detail)
 })
-const statusFootnoteText = computed(() => (isDaemonRunning.value ? '等待 Cron 调度' : '后台自动巡检'))
+const statusFootnoteText = computed(() =>
+  isDaemonRunning.value ? t('等待 Cron 调度', 'Waiting for Cron schedule') : t('后台自动巡检', 'Background automatic inspection'),
+)
 
 watch(logText, () => {
   if (shouldFollowLatestLog.value) {
@@ -197,7 +197,7 @@ async function loadAll() {
     status.value = nextStatus
     accounts.value = accountResponse.items
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载账号巡检失败')
+    message.error(errorText(error, '加载账号巡检失败', 'Failed to load account inspection'))
   } finally {
     isLoading.value = false
   }
@@ -235,7 +235,7 @@ function normalizedRules(): CodexKeeperPriorityRule[] {
 async function saveSettings() {
   const rules = normalizedRules()
   if (rules.length !== priorityRules.value.length) {
-    message.error('账号类型不可为空或重复，优先级必须在 0 ~ 20')
+    message.error(t('账号类型不可为空或重复，优先级必须在 0 ~ 20', 'Account types cannot be empty or duplicated, and priorities must be 0-20'))
     return
   }
   isSaving.value = true
@@ -246,9 +246,9 @@ async function saveSettings() {
     }
     const saved = await updateCodexKeeperSettings(payload)
     applySettings(saved)
-    message.success('巡检配置已保存')
+    message.success(t('巡检配置已保存', 'Inspection settings saved'))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '保存巡检配置失败')
+    message.error(errorText(error, '保存巡检配置失败', 'Failed to save inspection settings'))
   } finally {
     isSaving.value = false
   }
@@ -258,7 +258,7 @@ async function loadSchedulePreview() {
   const scheduleCron = form.schedule_cron.trim()
   if (!scheduleCron) {
     nextRunTimes.value = []
-    schedulePreviewError.value = '请填写 Cron 表达式'
+    schedulePreviewError.value = t('请填写 Cron 表达式', 'Enter a Cron expression')
     return
   }
   try {
@@ -273,8 +273,11 @@ async function loadSchedulePreview() {
       return
     }
     nextRunTimes.value = []
-    schedulePreviewError.value =
-      error instanceof Error ? error.message : 'Cron 表达式无效，请使用 5 段格式'
+    schedulePreviewError.value = errorText(
+      error,
+      'Cron 表达式无效，请使用 5 段格式',
+      'Invalid Cron expression. Use the 5-field format',
+    )
   }
 }
 
@@ -294,7 +297,7 @@ async function runAction(action: () => Promise<void>, successText: string) {
     message.success(successText)
     await loadStatus()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '操作失败')
+    message.error(errorText(error, '操作失败', 'Operation failed'))
   } finally {
     isActing.value = false
   }
@@ -430,34 +433,34 @@ function scrollLogToTop() {
 
 async function copyLogText() {
   if (!logText.value) {
-    message.info('暂无日志可复制')
+    message.info(t('暂无日志可复制', 'No logs to copy'))
     return
   }
   try {
     await copyToClipboard(logText.value)
-    message.success('维护日志已复制')
+    message.success(t('维护日志已复制', 'Maintenance logs copied'))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '复制失败')
+    message.error(errorText(error, '复制失败', 'Copy failed'))
   }
 }
 
-const priorityColumns: DataTableColumns<CodexKeeperPriorityRule> = [
+const priorityColumns = computed<DataTableColumns<CodexKeeperPriorityRule>>(() => [
   {
-    title: '账号类型',
+    title: t('账号类型', 'Account Type'),
     key: 'account_type',
     minWidth: 132,
     render: (row) =>
       h(NInput, {
         size: 'small',
         value: row.account_type,
-        placeholder: '例如 pro_20x',
+        placeholder: t('例如 pro_20x', 'For example, pro_20x'),
         onUpdateValue: (value: string) => {
           row.account_type = value
         },
       }),
   },
   {
-    title: '优先级',
+    title: t('优先级', 'Priority'),
     key: 'priority',
     width: 112,
     render: (row) =>
@@ -479,10 +482,10 @@ const priorityColumns: DataTableColumns<CodexKeeperPriorityRule> = [
       h(
         NButton,
         { size: 'tiny', quaternary: true, type: 'error', onClick: () => removeRule(row) },
-        { default: () => '移除' },
+        { default: () => t('移除', 'Remove') },
       ),
   },
-]
+])
 
 onMounted(() => {
   void loadAll()
@@ -507,13 +510,13 @@ onBeforeUnmount(() => {
   <section class="page inspection-page">
     <div class="page-header">
       <div>
-        <h1 class="page-title">巡检设置</h1>
-        <p class="page-subtitle">维护 Codex auth file 的健康状态和调度优先级</p>
+        <h1 class="page-title">{{ t('巡检设置', 'Inspection Settings') }}</h1>
+        <p class="page-subtitle">{{ t('维护 Codex auth file 的健康状态和调度优先级', 'Maintain Codex auth file health and scheduling priorities') }}</p>
       </div>
       <NSpace>
-        <NButton secondary :loading="isLoading" @click="loadAll">重新加载</NButton>
+        <NButton secondary :loading="isLoading" @click="loadAll">{{ t('重新加载', 'Reload') }}</NButton>
         <NButton type="primary" :loading="isSaving" :disabled="isRunning" @click="saveSettings">
-          保存配置
+          {{ t('保存配置', 'Save Settings') }}
         </NButton>
       </NSpace>
     </div>
@@ -523,7 +526,7 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <Activity :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">运行状态</div>
+        <div class="metric-label">{{ t('运行状态', 'Run Status') }}</div>
         <div class="metric-value inspection-status-value" :title="statusDetailText">
           <NTag class="inspection-status-tag" :type="stateType" size="small" :bordered="false">
             {{ statusDetailText }}
@@ -535,31 +538,31 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <Users :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">账号总数</div>
+        <div class="metric-label">{{ t('账号总数', 'Total Accounts') }}</div>
         <div class="metric-value">{{ formatInteger(accountTotalCount) }}</div>
-        <div class="metric-footnote">全部 auth file</div>
+        <div class="metric-footnote">{{ t('全部 auth file', 'All auth files') }}</div>
       </div>
       <div class="metric-card is-green">
         <div class="metric-icon" aria-hidden="true">
           <ShieldCheck :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">启用中</div>
+        <div class="metric-label">{{ t('启用中', 'Enabled') }}</div>
         <div class="metric-value">{{ formatInteger(enabledAccountCount) }}</div>
-        <div class="metric-footnote">可参与调度</div>
+        <div class="metric-footnote">{{ t('可参与调度', 'Available for scheduling') }}</div>
       </div>
       <div class="metric-card is-warning">
         <div class="metric-icon" aria-hidden="true">
           <PauseCircle :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">已禁用</div>
+        <div class="metric-label">{{ t('已禁用', 'Disabled') }}</div>
         <div class="metric-value">{{ formatInteger(disabledAccountCount) }}</div>
-        <div class="metric-footnote">停用账号</div>
+        <div class="metric-footnote">{{ t('停用账号', 'Inactive accounts') }}</div>
       </div>
       <div class="metric-card is-danger">
         <div class="metric-icon" aria-hidden="true">
           <ShieldAlert :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">401报错</div>
+        <div class="metric-label">{{ t('401报错', '401 Errors') }}</div>
         <div class="metric-value">{{ formatInteger(unauthorizedErrorAccountCount) }}</div>
         <div class="metric-footnote">HTTP 401</div>
       </div>
@@ -567,9 +570,9 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <Gauge :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">额度耗尽</div>
+        <div class="metric-label">{{ t('额度耗尽', 'Quota Exhausted') }}</div>
         <div class="metric-value">{{ formatInteger(quotaExhaustedAccountCount) }}</div>
-        <div class="metric-footnote">临时降级</div>
+        <div class="metric-footnote">{{ t('临时降级', 'Temporary downgrade') }}</div>
       </div>
     </div>
 
@@ -577,25 +580,25 @@ onBeforeUnmount(() => {
       <section class="panel inspection-config-panel">
         <div class="panel-inner config-panel-inner">
           <div class="section-heading">
-            <h2 class="section-title">巡检配置</h2>
+            <h2 class="section-title">{{ t('巡检配置', 'Inspection Configuration') }}</h2>
             <NSpace class="config-actions" size="small">
               <NButton
                 size="small"
                 secondary
                 :loading="isActing"
                 :disabled="isRunOnceBlocked"
-                @click="runAction(runCodexKeeperOnce, '已开始执行一轮')"
+                @click="runAction(runCodexKeeperOnce, t('已开始执行一轮', 'Started one inspection run'))"
               >
-                执行一轮
+                {{ t('执行一轮', 'Run Once') }}
               </NButton>
               <NButton
                 size="small"
                 type="primary"
                 :loading="isActing"
                 :disabled="isDaemonRunning"
-                @click="runAction(startCodexKeeper, '已开始自动巡检')"
+                @click="runAction(startCodexKeeper, t('已开始自动巡检', 'Automatic inspection started'))"
               >
-                开始自动巡检
+                {{ t('开始自动巡检', 'Start Automatic Inspection') }}
               </NButton>
               <NButton
                 size="small"
@@ -603,22 +606,22 @@ onBeforeUnmount(() => {
                 type="warning"
                 :loading="isActing"
                 :disabled="!isDaemonRunning"
-                @click="runAction(stopCodexKeeper, '已请求停止')"
+                @click="runAction(stopCodexKeeper, t('已请求停止', 'Stop requested'))"
               >
-                停止
+                {{ t('停止', 'Stop') }}
               </NButton>
             </NSpace>
           </div>
           <NForm class="config-form" :model="form" label-placement="top" size="small">
             <div class="config-sections">
               <section class="config-block">
-                <h3 class="config-block-title">调度</h3>
+                <h3 class="config-block-title">{{ t('调度', 'Schedule') }}</h3>
                 <div class="schedule-grid">
-                  <NFormItem label="Cron 表达式">
-                    <NInput v-model:value="form.schedule_cron" placeholder="例如 */30 * * * *" />
+                  <NFormItem :label="t('Cron 表达式', 'Cron Expression')">
+                    <NInput v-model:value="form.schedule_cron" :placeholder="t('例如 */30 * * * *', 'For example, */30 * * * *')" />
                   </NFormItem>
                   <div class="schedule-preview">
-                    <div class="preview-title">后续 5 次调用</div>
+                    <div class="preview-title">{{ t('后续 5 次调用', 'Next 5 Runs') }}</div>
                     <div v-if="schedulePreviewError" class="preview-error">
                       {{ schedulePreviewError }}
                     </div>
@@ -627,17 +630,17 @@ onBeforeUnmount(() => {
                         {{ formatDateTime(time) }}
                       </span>
                     </div>
-                    <div v-else class="preview-muted">填写 Cron 表达式后显示</div>
+                    <div v-else class="preview-muted">{{ t('填写 Cron 表达式后显示', 'Enter a Cron expression to preview') }}</div>
                   </div>
                 </div>
                 <div class="conditional-refresh-grid">
-                  <NFormItem label="按条件扫描间隔">
+                  <NFormItem :label="t('按条件扫描间隔', 'Conditional Scan Interval')">
                     <NSelect
                       v-model:value="form.conditional_refresh_interval_seconds"
                       :options="conditionalRefreshIntervalOptions"
                     />
                   </NFormItem>
-                  <NFormItem label="账号刷新缓存（分钟）">
+                  <NFormItem :label="t('账号刷新缓存（分钟）', 'Account Refresh Cache (minutes)')">
                     <NInputNumber
                       v-model:value="form.account_refresh_cache_minutes"
                       :min="1"
@@ -647,30 +650,30 @@ onBeforeUnmount(() => {
                 </div>
                 <div class="conditional-refresh-help">
                   <p>
-                    <strong>按条件扫描间隔：</strong>后台自动巡检开启后，每隔多久检查一次是否有账号需要刷新；会查找缓存时间内有实际请求的账号、额度刷新时间已到的账号、检测异常账号，并同步本地记录与 CPA 当前账号列表的差异。
+                    <strong>{{ t('按条件扫描间隔：', 'Conditional scan interval:') }}</strong>{{ t('后台自动巡检开启后，每隔多久检查一次是否有账号需要刷新；会查找缓存时间内有实际请求的账号、额度刷新时间已到的账号、检测异常账号，并同步本地记录与 CPA 当前账号列表的差异。', 'How often automatic inspection checks whether accounts need refreshing after it is enabled. It looks for accounts with actual requests during the cache window, expired quota refresh times, inspection errors, and differences between local records and the current CPA account list.') }}
                   </p>
                   <p>
-                    <strong>账号刷新缓存：</strong>控制自动任务的防重复时间；同一账号在缓存时间内不会被自动巡检或按条件扫描重复刷新，手动刷新会绕过缓存但会更新缓存时间。
+                    <strong>{{ t('账号刷新缓存：', 'Account refresh cache:') }}</strong>{{ t('控制自动任务的防重复时间；同一账号在缓存时间内不会被自动巡检或按条件扫描重复刷新，手动刷新会绕过缓存但会更新缓存时间。', 'Controls duplicate prevention for automatic tasks. The same account will not be refreshed repeatedly by automatic inspection or conditional scans during the cache window. Manual refresh bypasses the cache but updates the cache time.') }}
                   </p>
                 </div>
               </section>
 
               <section class="config-block">
-                <h3 class="config-block-title">执行参数</h3>
+                <h3 class="config-block-title">{{ t('执行参数', 'Execution Parameters') }}</h3>
                 <div class="params-grid">
-                  <NFormItem label="额度阈值（%）">
+                  <NFormItem :label="t('额度阈值（%）', 'Quota Threshold (%)')">
                     <NInputNumber v-model:value="form.quota_threshold" :min="0" :max="100" />
                   </NFormItem>
-                  <NFormItem label="额度检测超时（秒）">
+                  <NFormItem :label="t('额度检测超时（秒）', 'Quota Check Timeout (seconds)')">
                     <NInputNumber v-model:value="form.usage_timeout_seconds" :min="1" />
                   </NFormItem>
-                  <NFormItem label="账号管理接口超时（秒）">
+                  <NFormItem :label="t('账号管理接口超时（秒）', 'Account API Timeout (seconds)')">
                     <NInputNumber v-model:value="form.cpa_timeout_seconds" :min="1" />
                   </NFormItem>
-                  <NFormItem label="失败重试次数">
+                  <NFormItem :label="t('失败重试次数', 'Failure Retries')">
                     <NInputNumber v-model:value="form.max_retries" :min="0" :max="5" />
                   </NFormItem>
-                  <NFormItem label="账号处理并发数">
+                  <NFormItem :label="t('账号处理并发数', 'Account Processing Concurrency')">
                     <NInputNumber v-model:value="form.worker_threads" :min="1" :max="64" />
                   </NFormItem>
                 </div>
@@ -678,8 +681,8 @@ onBeforeUnmount(() => {
                   <NFormItem class="switch-form-item">
                     <div class="switch-setting">
                       <div class="switch-copy">
-                        <span class="switch-title">只检查不修改</span>
-                        <p class="switch-help">开启后只模拟处理，不会禁用账号或调整优先级。</p>
+                        <span class="switch-title">{{ t('只检查不修改', 'Check Only') }}</span>
+                        <p class="switch-help">{{ t('开启后只模拟处理，不会禁用账号或调整优先级。', 'When enabled, processing is simulated and accounts are not disabled or reprioritized.') }}</p>
                       </div>
                       <NSwitch v-model:value="form.dry_run" class="switch-control" />
                     </div>
@@ -687,9 +690,9 @@ onBeforeUnmount(() => {
                   <NFormItem class="switch-form-item">
                     <div class="switch-setting">
                       <div class="switch-copy">
-                        <span class="switch-title">启用凭证 WebSocket</span>
+                        <span class="switch-title">{{ t('启用凭证 WebSocket', 'Enable Credential WebSocket') }}</span>
                         <p class="switch-help">
-                          刷新时为每个 Codex 凭证写入 websockets=true，用于 Responses API 的 WebSocket 传输。
+                          {{ t('刷新时为每个 Codex 凭证写入 websockets=true，用于 Responses API 的 WebSocket 传输。', 'During refresh, write websockets=true to each Codex credential for Responses API WebSocket transport.') }}
                         </p>
                       </div>
                       <NSwitch
@@ -701,8 +704,8 @@ onBeforeUnmount(() => {
                   <NFormItem class="switch-form-item">
                     <div class="switch-setting">
                       <div class="switch-copy">
-                        <span class="switch-title">启动后自动巡检</span>
-                        <p class="switch-help">每次 CPA-Helper 启动后，自动按上面的计划检查账号。</p>
+                        <span class="switch-title">{{ t('启动后自动巡检', 'Auto Inspect on Startup') }}</span>
+                        <p class="switch-help">{{ t('每次 CPA-Helper 启动后，自动按上面的计划检查账号。', 'Automatically inspect accounts using the schedule above whenever CPA-Helper starts.') }}</p>
                       </div>
                       <NSwitch v-model:value="form.auto_start_daemon" class="switch-control" />
                     </div>
@@ -712,22 +715,22 @@ onBeforeUnmount(() => {
             </div>
           </NForm>
           <section class="config-block runtime-block">
-            <h3 class="config-block-title">运行信息</h3>
+            <h3 class="config-block-title">{{ t('运行信息', 'Runtime Information') }}</h3>
             <div class="runtime-info-grid">
               <div class="runtime-stat">
                 <span class="runtime-label">CLIProxyAPI</span>
                 <strong class="runtime-value">
-                  {{ status ? '使用系统设置中的地址和管理密钥' : '等待加载' }}
+                  {{ status ? t('使用系统设置中的地址和管理密钥', 'Using the system settings URL and admin key') : t('等待加载', 'Waiting to load') }}
                 </strong>
               </div>
               <div class="runtime-stat">
-                <span class="runtime-label">最近开始</span>
+                <span class="runtime-label">{{ t('最近开始', 'Last Started') }}</span>
                 <strong class="runtime-value">
                   {{ formatDateTime(status?.last_started_at ?? null) }}
                 </strong>
               </div>
               <div class="runtime-stat">
-                <span class="runtime-label">最近完成</span>
+                <span class="runtime-label">{{ t('最近完成', 'Last Finished') }}</span>
                 <strong class="runtime-value">
                   {{ formatDateTime(status?.last_finished_at ?? null) }}
                 </strong>
@@ -740,11 +743,11 @@ onBeforeUnmount(() => {
       <section class="panel priority-rules-panel">
         <div class="panel-inner">
           <div class="section-heading">
-            <h2 class="section-title">账号类型优先级</h2>
-            <NButton size="small" secondary @click="addRule">新增规则</NButton>
+            <h2 class="section-title">{{ t('账号类型优先级', 'Account Type Priorities') }}</h2>
+            <NButton size="small" secondary @click="addRule">{{ t('新增规则', 'Add Rule') }}</NButton>
           </div>
           <p class="section-hint">
-            账号当前优先级超过 20 时视为手动优先，巡检不会覆盖；0 ~ 20 会按这里的账号类型规则维护。
+            {{ t('账号当前优先级超过 20 时视为手动优先，巡检不会覆盖；0 ~ 20 会按这里的账号类型规则维护。', 'Current account priorities above 20 are treated as manual priority and will not be overwritten. Priorities from 0 to 20 are maintained using the account type rules here.') }}
           </p>
           <NDataTable
             class="priority-table"
@@ -761,19 +764,19 @@ onBeforeUnmount(() => {
     <section class="panel log-panel">
       <div class="panel-inner log-panel-inner">
         <div class="section-heading">
-          <h2 class="section-title">维护日志</h2>
+          <h2 class="section-title">{{ t('维护日志', 'Maintenance Logs') }}</h2>
           <NSpace class="log-actions" size="small">
             <NButton secondary :disabled="!logText" @click="copyLogText">
               <template #icon>
                 <NIcon :component="Copy" />
               </template>
-              复制日志
+              {{ t('复制日志', 'Copy Logs') }}
             </NButton>
-            <NButton secondary :loading="isActing" @click="runAction(clearCodexKeeperLogs, '日志已清空')">
+            <NButton secondary :loading="isActing" @click="runAction(clearCodexKeeperLogs, t('日志已清空', 'Logs cleared'))">
               <template #icon>
                 <NIcon :component="Trash2" />
               </template>
-              清空日志
+              {{ t('清空日志', 'Clear Logs') }}
             </NButton>
           </NSpace>
         </div>
@@ -781,22 +784,22 @@ onBeforeUnmount(() => {
           ref="logBodyRef"
           class="log-view"
           role="log"
-          aria-label="维护日志"
+          :aria-label="t('维护日志', 'Maintenance Logs')"
           @scroll="handleLogScroll"
         >
-          <div v-if="displayedLogLines.length === 0" class="log-empty">暂无日志</div>
+          <div v-if="displayedLogLines.length === 0" class="log-empty">{{ t('暂无日志', 'No logs') }}</div>
           <div v-else class="log-lines">
             <div
               v-for="line in displayedLogLines"
               :key="line.key"
               class="log-line"
               :class="`is-${line.tone}`"
-              :title="line.raw"
+              :title="serverText(line.message, '维护日志', 'Maintenance log')"
             >
               <time class="log-time">{{ line.time }}</time>
               <span class="log-level">{{ line.level }}</span>
               <span class="log-component">{{ line.component }}</span>
-              <span class="log-message">{{ line.message }}</span>
+              <span class="log-message">{{ serverText(line.message, '维护日志', 'Maintenance log') }}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/features/codex-keeper/views/CodexKeeperStatusView.vue
+++ b/frontend/src/features/codex-keeper/views/CodexKeeperStatusView.vue
@@ -53,6 +53,7 @@ import type {
   CodexKeeperQuotaWindowUsage,
   CodexKeeperStatus,
 } from '@/shared/types/api'
+import { useI18n } from '@/shared/i18n'
 import {
   BEIJING_TIME_ZONE,
   formatCompact,
@@ -100,6 +101,7 @@ const normalTableScrollX = 1816
 const KEEPER_STATUS_POLL_INTERVAL_MS = 3000
 const REFRESH_STATUS_POLL_INTERVAL_MS = 1500
 const message = useMessage()
+const { currentLanguage, errorText, keeperStatusText, serverText, t } = useI18n()
 const isLoading = ref(false)
 const isBulkDeleting = ref(false)
 const isBulkRefreshing = ref(false)
@@ -153,8 +155,8 @@ const priorityRuleMap = computed(() =>
   Object.fromEntries(priorityRules.value.map((rule) => [rule.account_type, rule.priority])),
 )
 const priorityFilterOptions = computed<Array<{ label: string; value: PriorityFilter }>>(() => [
-  { label: '全部优先级', value: 'all' },
-  { label: '手动优先 >20', value: 'high' },
+  { label: t('全部优先级', 'All Priorities'), value: 'all' },
+  { label: t('手动优先 >20', 'Manual Priority >20'), value: 'high' },
   ...[...priorityRules.value]
     .filter((rule) => rule.priority >= 0 && rule.priority <= 20)
     .sort((left, right) => {
@@ -167,25 +169,25 @@ const priorityFilterOptions = computed<Array<{ label: string; value: PriorityFil
       label: `${formatInteger(rule.priority)} (${rule.account_type})`,
       value: priorityTypeFilter(rule.account_type),
     })),
-  { label: '临时降级', value: 'minusOne' },
-  { label: '手动低优先 <-1', value: 'low' },
+  { label: t('临时降级', 'Temporary Downgrade'), value: 'minusOne' },
+  { label: t('手动低优先 <-1', 'Manual Low Priority <-1'), value: 'low' },
 ])
-const accountDisplaySizeOptions: Array<{ label: string; value: AccountDisplaySize }> = [
+const accountDisplaySizeOptions = computed<Array<{ label: string; value: AccountDisplaySize }>>(() => [
   { label: '50', value: 50 },
   { label: '100', value: 100 },
   { label: '150', value: 150 },
   { label: '200', value: 200 },
-  { label: '全部', value: 'all' },
-]
-const accountListViewOptions = [
-  { label: '表格', key: 'table', icon: () => h(NIcon, null, { default: () => h(Table2) }) },
-  { label: '进度条卡片', key: 'bar', icon: () => h(NIcon, null, { default: () => h(BarChart3) }) },
-  { label: '圆环卡片', key: 'ring', icon: () => h(NIcon, null, { default: () => h(CircleDot) }) },
-]
-const quotaSortOptions = [
-  { label: '天', key: 'quotaDay' },
-  { label: '月/周', key: 'quotaWeek' },
-]
+  { label: t('全部', 'All'), value: 'all' },
+])
+const accountListViewOptions = computed(() => [
+  { label: t('表格', 'Table'), key: 'table', icon: () => h(NIcon, null, { default: () => h(Table2) }) },
+  { label: t('进度条卡片', 'Progress Cards'), key: 'bar', icon: () => h(NIcon, null, { default: () => h(BarChart3) }) },
+  { label: t('圆环卡片', 'Ring Cards'), key: 'ring', icon: () => h(NIcon, null, { default: () => h(CircleDot) }) },
+])
+const quotaSortOptions = computed(() => [
+  { label: t('天', 'Day'), key: 'quotaDay' },
+  { label: t('月/周', 'Month/Week'), key: 'quotaWeek' },
+])
 
 const accountTypeOptions = computed(() =>
   [...new Set(accounts.value.map((item) => item.account_type).filter(Boolean))]
@@ -248,19 +250,15 @@ const keeperStateType = computed(() => {
 const keeperStatusDetailText = computed(() => {
   const detail = keeperStatus.value?.detail
   if (isKeeperDaemonRunning.value && !isKeeperRunning.value) {
-    return '自动巡检已开启'
+    return t('自动巡检已开启', 'Automatic inspection is enabled')
   }
   if (!detail) {
-    return '未运行'
+    return t('未运行', 'Not running')
   }
-  return detail
-    .replace(/守护运行中/g, '自动巡检运行中')
-    .replace(/守护进程/g, '后台自动巡检')
-    .replace(/守护任务/g, '自动巡检任务')
-    .replace(/守护已启动/g, '已开始自动巡检')
+  return keeperStatusText(detail)
 })
 const keeperStatusFootnoteText = computed(() =>
-  isKeeperDaemonRunning.value ? '等待 Cron 调度' : '后台自动巡检',
+  isKeeperDaemonRunning.value ? t('等待 Cron 调度', 'Waiting for Cron schedule') : t('后台自动巡检', 'Background automatic inspection'),
 )
 const unauthorizedErrorAccountCount = computed(
   () => accounts.value.filter((account) => account.last_status_code === 401).length,
@@ -279,12 +277,12 @@ const isTableView = computed(() => accountListViewMode.value === 'table')
 const isBarCardView = computed(() => accountListViewMode.value === 'bar')
 const accountListViewLabel = computed(() => {
   if (accountListViewMode.value === 'bar') {
-    return '进度条卡片'
+    return t('进度条卡片', 'Progress Cards')
   }
   if (accountListViewMode.value === 'ring') {
-    return '圆环卡片'
+    return t('圆环卡片', 'Ring Cards')
   }
-  return '表格'
+  return t('表格', 'Table')
 })
 const sortedCardAccounts = computed(() => [
   ...filteredDisabledAccounts.value,
@@ -349,18 +347,18 @@ const showCardLoadingState = computed(() => isLoading.value && accounts.value.le
 const displaySizeHelpText = computed(() =>
   isTableView.value
     ? isDisplayAllAccounts.value
-      ? '当前筛选结果全部展示，账号较多时自动使用虚拟滚动。'
-      : `每个分组每页显示 ${accountDisplaySize.value} 个账号。`
+      ? t('当前筛选结果全部展示，账号较多时自动使用虚拟滚动。', 'All filtered results are shown. Virtual scrolling is used automatically for large account sets.')
+      : t(`每个分组每页显示 ${accountDisplaySize.value} 个账号。`, `${accountDisplaySize.value} accounts per group per page.`)
     : isDisplayAllAccounts.value
-      ? '当前筛选结果全部以卡片展示，账号较多时使用轻量渲染优化。'
-      : `统一列表每页显示 ${accountDisplaySize.value} 个账号。`,
+      ? t('当前筛选结果全部以卡片展示，账号较多时使用轻量渲染优化。', 'All filtered results are shown as cards. Lightweight rendering is used for large account sets.')
+      : t(`统一列表每页显示 ${accountDisplaySize.value} 个账号。`, `${accountDisplaySize.value} accounts per page in the unified list.`),
 )
 const activeQuotaSortLabel = computed(() => {
   if (accountSort.key === 'quotaDay') {
-    return '天'
+    return t('天', 'Day')
   }
   if (accountSort.key === 'quotaWeek') {
-    return '月/周'
+    return t('月/周', 'Month/Week')
   }
   return ''
 })
@@ -405,9 +403,12 @@ function accountDisplayText(
   pageCount: number,
 ): string {
   if (isDisplayAllAccounts.value) {
-    return `显示 ${visibleCount} / ${totalCount} 个账号`
+    return t(`显示 ${visibleCount} / ${totalCount} 个账号`, `Showing ${visibleCount} / ${totalCount} accounts`)
   }
-  return `第 ${clampPage(page, pageCount)} / ${pageCount} 页，显示 ${visibleCount} / ${totalCount} 个账号`
+  return t(
+    `第 ${clampPage(page, pageCount)} / ${pageCount} 页，显示 ${visibleCount} / ${totalCount} 个账号`,
+    `Page ${clampPage(page, pageCount)} / ${pageCount}, showing ${visibleCount} / ${totalCount} accounts`,
+  )
 }
 
 function clampPage(page: number, pageCount: number): number {
@@ -508,7 +509,7 @@ function saveAccountStatusPreferences() {
       }),
     )
   } catch {
-    // 本地存储不可用时不影响页面继续使用。
+    // Keep the page usable when local storage is unavailable.
   }
 }
 const selectedDisabledAccountNames = computed(() =>
@@ -541,13 +542,19 @@ const bulkDeletePreviewOverflow = computed(() =>
 )
 const bulkDeleteDialogTitle = computed(() =>
   bulkDeleteDialog.source === 'disabled401'
-    ? '批量删除 401 已禁用账号'
-    : '批量删除已禁用账号',
+    ? t('批量删除 401 已禁用账号', 'Bulk Delete 401 Disabled Accounts')
+    : t('批量删除已禁用账号', 'Bulk Delete Disabled Accounts'),
 )
 const bulkDeleteWarningText = computed(() =>
   bulkDeleteDialog.source === 'disabled401'
-    ? `将删除当前筛选下 ${selectedDisabledCount.value} 个 HTTP 401 已禁用账号，并从 CPA 删除 auth file。此操作不可恢复。`
-    : `将删除已选 ${selectedDisabledCount.value} 个已禁用账号，并从 CPA 删除 auth file。此操作不可恢复。`,
+    ? t(
+        `将删除当前筛选下 ${selectedDisabledCount.value} 个 HTTP 401 已禁用账号，并从 CPA 删除 auth file。此操作不可恢复。`,
+        `This will delete ${selectedDisabledCount.value} HTTP 401 disabled accounts in the current filter and remove their auth files from CPA. This cannot be undone.`,
+      )
+    : t(
+        `将删除已选 ${selectedDisabledCount.value} 个已禁用账号，并从 CPA 删除 auth file。此操作不可恢复。`,
+        `This will delete ${selectedDisabledCount.value} selected disabled accounts and remove their auth files from CPA. This cannot be undone.`,
+      ),
 )
 const canSubmitPriority = computed(() => {
   if (priorityDialog.mode === 'default') {
@@ -559,19 +566,19 @@ const canSubmitPriority = computed(() => {
   }
   return priorityDialog.mode === 'low' ? value < -1 : value > 20
 })
-const priorityDialogTitle = computed(() => '修改优先级')
+const priorityDialogTitle = computed(() => t('修改优先级', 'Change Priority'))
 const priorityDialogHint = computed(() => {
   if (priorityDialog.mode === 'low') {
-    return '手动低优先级必须小于 -1，巡检永远不会自动调整。'
+    return t('手动低优先级必须小于 -1，巡检永远不会自动调整。', 'Manual low priority must be less than -1. Inspection will never adjust it automatically.')
   }
   if (priorityDialog.mode === 'high') {
-    return '手动优先必须大于 20，额度耗尽时会临时降为 -1，恢复后回到该值。'
+    return t('手动优先必须大于 20，额度耗尽时会临时降为 -1，恢复后回到该值。', 'Manual priority must be greater than 20. When quota is exhausted it is temporarily lowered to -1 and restored to this value after recovery.')
   }
   const account = priorityDialog.account
   const value = account ? defaultPriority(account) : null
   return value === null
-    ? '该账号类型没有配置默认优先级，不能使用类型默认值。'
-    : `将优先级设置为当前账号类型默认值 ${value}。`
+    ? t('该账号类型没有配置默认优先级，不能使用类型默认值。', 'This account type has no default priority, so the type default cannot be used.')
+    : t(`将优先级设置为当前账号类型默认值 ${value}。`, `Set the priority to the current account type default: ${value}.`)
 })
 const priorityDialogBounds = computed(() => {
   if (priorityDialog.mode === 'low') {
@@ -585,10 +592,12 @@ const priorityDialogBounds = computed(() => {
 const priorityModeOptions = computed(() => {
   const defaultValue = priorityDialog.account ? defaultPriority(priorityDialog.account) : null
   return [
-    { label: '手动低优先 (< -1)', value: 'low' },
-    { label: '手动优先 (> 20)', value: 'high' },
+    { label: t('手动低优先 (< -1)', 'Manual Low Priority (< -1)'), value: 'low' },
+    { label: t('手动优先 (> 20)', 'Manual Priority (> 20)'), value: 'high' },
     {
-      label: defaultValue === null ? '类型默认优先级（不可用）' : `类型默认优先级 (${defaultValue})`,
+      label: defaultValue === null
+        ? t('类型默认优先级（不可用）', 'Type Default Priority (unavailable)')
+        : t(`类型默认优先级 (${defaultValue})`, `Type Default Priority (${defaultValue})`),
       value: 'default',
       disabled: defaultValue === null,
     },
@@ -843,12 +852,12 @@ function isFreeQuotaWindow(account: CodexKeeperAccount): boolean {
 
 function quotaWindowLabels(account: CodexKeeperAccount): { primary: string; secondary: string } {
   if (isFreeQuotaWindow(account)) {
-    return { primary: '月限额', secondary: '次限额' }
+    return { primary: t('月限额', 'Monthly Limit'), secondary: t('次限额', 'Secondary Limit') }
   }
   if (isPaidQuotaWindow(account)) {
-    return { primary: '5小时限额', secondary: '周限额' }
+    return { primary: t('5小时限额', '5-Hour Limit'), secondary: t('周限额', 'Weekly Limit') }
   }
-  return { primary: '主', secondary: '次' }
+  return { primary: t('主', 'Primary'), secondary: t('次', 'Secondary') }
 }
 
 function shouldShowQuotaWindow(account: CodexKeeperAccount): boolean {
@@ -926,7 +935,7 @@ function formatQuotaResetTime(value: string | null): string | null {
   if (Number.isNaN(date.getTime())) {
     return null
   }
-  return new Intl.DateTimeFormat('zh-CN', {
+  return new Intl.DateTimeFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     timeZone: BEIJING_TIME_ZONE,
     month: '2-digit',
     day: '2-digit',
@@ -946,50 +955,64 @@ function quotaText(account: CodexKeeperAccount): string {
       const resetTime = formatQuotaResetTime(item.resetAt)
       const usageText = quotaWindowUsageText(item)
       return resetTime
-        ? `${item.label}剩余 ${item.remainingPercent}%，刷新 ${resetTime}，${usageText}`
-        : `${item.label}剩余 ${item.remainingPercent}%，${usageText}`
+        ? t(
+            `${item.label}剩余 ${item.remainingPercent}%，刷新 ${resetTime}，${usageText}`,
+            `${item.label} ${item.remainingPercent}% remaining, refreshes ${resetTime}, ${usageText}`,
+          )
+        : t(
+            `${item.label}剩余 ${item.remainingPercent}%，${usageText}`,
+            `${item.label} ${item.remainingPercent}% remaining, ${usageText}`,
+          )
     })
     .join(' / ')
 }
 
 function quotaWindowUsageText(item: QuotaWindowItem): string {
   if (!item.resetAt || item.usage?.stale === true) {
-    return '额度数据需刷新'
+    return t('额度数据需刷新', 'Quota data needs refresh')
   }
   if (!item.usage) {
-    return '本窗口暂无用量'
+    return t('本窗口暂无用量', 'No usage in this window')
   }
-  return `${formatInteger(item.usage.records)} 次 / ${formatCompact(item.usage.total_tokens)} Tokens / ${formatUsd(item.usage.estimated_cost_usd)}`
+  return t(
+    `${formatInteger(item.usage.records)} 次 / ${formatCompact(item.usage.total_tokens)} Tokens / ${formatUsd(item.usage.estimated_cost_usd)}`,
+    `${formatInteger(item.usage.records)} requests / ${formatCompact(item.usage.total_tokens)} Tokens / ${formatUsd(item.usage.estimated_cost_usd)}`,
+  )
 }
 
 function quotaWindowUsageTags(item: QuotaWindowItem): QuotaUsageTag[] {
   if (!item.resetAt || item.usage?.stale === true) {
-    return [{ label: '状态', value: '需刷新', tone: 'stale' }]
+    return [{ label: t('状态', 'Status'), value: t('需刷新', 'Needs refresh'), tone: 'stale' }]
   }
   const usage = item.usage
   return [
-    { label: '请求', value: formatInteger(usage?.records ?? 0) },
+    { label: t('请求', 'Requests'), value: formatInteger(usage?.records ?? 0) },
     { label: 'Tokens', value: formatCompact(usage?.total_tokens ?? 0) },
-    { label: '费用', value: formatUsd(usage?.estimated_cost_usd ?? 0) },
+    { label: t('费用', 'Cost'), value: formatUsd(usage?.estimated_cost_usd ?? 0) },
   ]
 }
 
 function quotaWindowResetText(item: QuotaWindowItem): string {
   const resetTime = formatQuotaResetTime(item.resetAt)
-  return resetTime ? `刷新 ${resetTime}` : '未记录刷新时间'
+  return resetTime ? t(`刷新 ${resetTime}`, `Refreshes ${resetTime}`) : t('未记录刷新时间', 'No refresh time recorded')
 }
 
 function quotaWindowUsageTitle(item: QuotaWindowItem): string {
   const usage = item.usage
   if (!item.resetAt || usage?.stale === true) {
-    return `${item.label} 额度数据需刷新`
+    return t(`${item.label} 额度数据需刷新`, `${item.label} quota data needs refresh`)
   }
   if (!usage) {
-    return `${item.label} 本窗口暂无用量`
+    return t(`${item.label} 本窗口暂无用量`, `${item.label} has no usage in this window`)
   }
   const unpriced =
-    usage.unpriced_records > 0 ? `，未计价 ${formatInteger(usage.unpriced_records)} 条` : ''
-  return `${item.label} 当前窗口：${formatInteger(usage.records)} 次请求，${formatCompact(usage.total_tokens)} Tokens，${formatUsd(usage.estimated_cost_usd)}${unpriced}`
+    usage.unpriced_records > 0
+      ? t(`，未计价 ${formatInteger(usage.unpriced_records)} 条`, `, ${formatInteger(usage.unpriced_records)} unpriced records`)
+      : ''
+  return t(
+    `${item.label} 当前窗口：${formatInteger(usage.records)} 次请求，${formatCompact(usage.total_tokens)} Tokens，${formatUsd(usage.estimated_cost_usd)}${unpriced}`,
+    `${item.label} current window: ${formatInteger(usage.records)} requests, ${formatCompact(usage.total_tokens)} Tokens, ${formatUsd(usage.estimated_cost_usd)}${unpriced}`,
+  )
 }
 
 function quotaWindowUsageTone(item: QuotaWindowItem): string {
@@ -997,19 +1020,19 @@ function quotaWindowUsageTone(item: QuotaWindowItem): string {
 }
 
 function latestActionText(account: CodexKeeperAccount): string {
-  return account.last_error?.trim() || account.latest_action?.trim() || '-'
+  const text = account.last_error?.trim() || account.latest_action?.trim()
+  return text ? serverText(text, '账号状态', 'Account status') : '-'
 }
 
 function disabledCardErrorText(account: CodexKeeperAccount): string {
   if (!account.disabled) {
     return ''
   }
-  return (
+  const text =
     account.last_error?.trim() ||
     account.latest_action?.trim() ||
-    disabledStatusCodeTitle(account) ||
-    '暂无报错信息'
-  )
+    disabledStatusCodeTitle(account)
+  return text ? serverText(text, '报错信息', 'Error details') : t('暂无报错信息', 'No error details')
 }
 
 function disabledStatusCodeText(account: CodexKeeperAccount): string | null {
@@ -1039,8 +1062,14 @@ function renderQuotaCell(account: CodexKeeperAccount) {
         {
           class: 'quota-window-item',
           title: resetTime
-            ? `${item.label}剩余 ${item.remainingPercent}%，刷新 ${resetTime}；${quotaWindowUsageTitle(item)}`
-            : `${item.label}剩余 ${item.remainingPercent}%；${quotaWindowUsageTitle(item)}`,
+            ? t(
+                `${item.label}剩余 ${item.remainingPercent}%，刷新 ${resetTime}；${quotaWindowUsageTitle(item)}`,
+                `${item.label} ${item.remainingPercent}% remaining, refreshes ${resetTime}; ${quotaWindowUsageTitle(item)}`,
+              )
+            : t(
+                `${item.label}剩余 ${item.remainingPercent}%；${quotaWindowUsageTitle(item)}`,
+                `${item.label} ${item.remainingPercent}% remaining; ${quotaWindowUsageTitle(item)}`,
+              ),
         },
         [
           h('div', { class: 'quota-window-head' }, [
@@ -1095,12 +1124,12 @@ function renderQuotaUsageCell(account: CodexKeeperAccount) {
 function renderAccountIdentityCell(account: CodexKeeperAccount) {
   const primary = account.email ?? account.name
   const statusCode = disabledStatusCodeText(account)
-  const statusLabel = `${account.disabled ? '已禁用' : '启用中'}${statusCode ? ` ${statusCode}` : ''}`
+  const statusLabel = `${account.disabled ? t('已禁用', 'Disabled') : t('启用中', 'Enabled')}${statusCode ? ` ${statusCode}` : ''}`
   return h(
     'div',
     {
       class: 'account-table-identity',
-      title: `${primary}\n${account.name}\n状态 ${statusLabel}`,
+      title: `${primary}\n${account.name}\n${t('状态', 'Status')} ${statusLabel}`,
     },
     [
       h('span', { class: 'account-table-email' }, primary),
@@ -1117,7 +1146,7 @@ function renderAccountIdentityCell(account: CodexKeeperAccount) {
 }
 
 function renderAccountTypeCell(account: CodexKeeperAccount) {
-  const typeLabel = account.account_type ?? '未知'
+  const typeLabel = account.account_type ?? t('未知', 'Unknown')
   return h(
     'span',
     { class: ['account-table-chip', 'is-type'], title: typeLabel },
@@ -1129,7 +1158,7 @@ function renderAccountPriorityCell(account: CodexKeeperAccount) {
   const priorityLabel = formatInteger(accountPriority(account))
   return h(
     'span',
-    { class: ['account-table-chip', 'is-priority'], title: `优先级 ${priorityLabel}` },
+    { class: ['account-table-chip', 'is-priority'], title: t(`优先级 ${priorityLabel}`, `Priority ${priorityLabel}`) },
     priorityLabel,
   )
 }
@@ -1170,7 +1199,7 @@ async function loadAccounts() {
     priorityRules.value = settings.priority_rules
     keeperStatus.value = nextStatus
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载账号状态失败')
+    message.error(errorText(error, '加载账号状态失败', 'Failed to load account status'))
   } finally {
     isLoading.value = false
   }
@@ -1300,16 +1329,16 @@ async function submitBulkDelete() {
       (key) => !deletedNames.has(String(key)),
     )
     if (result.failed.length > 0 && result.deleted.length > 0) {
-      message.warning(`批量删除完成：成功 ${result.deleted.length} 个，失败 ${result.failed.length} 个`)
+      message.warning(t(`批量删除完成：成功 ${result.deleted.length} 个，失败 ${result.failed.length} 个`, `Bulk delete complete: ${result.deleted.length} succeeded, ${result.failed.length} failed`))
     } else if (result.failed.length > 0) {
-      message.error(`批量删除失败：失败 ${result.failed.length} 个`)
+      message.error(t(`批量删除失败：失败 ${result.failed.length} 个`, `Bulk delete failed: ${result.failed.length} failed`))
     } else {
-      message.success(`已删除 ${result.deleted.length} 个已禁用账号`)
+      message.success(t(`已删除 ${result.deleted.length} 个已禁用账号`, `Deleted ${result.deleted.length} disabled accounts`))
     }
     bulkDeleteDialog.show = false
     await loadAccounts()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '批量删除失败')
+    message.error(errorText(error, '批量删除失败', 'Bulk delete failed'))
   } finally {
     isBulkDeleting.value = false
   }
@@ -1368,7 +1397,7 @@ async function submitPriorityDialog() {
     priorityDialog.account,
     'priority',
     () => updateCodexKeeperPriority(priorityDialog.account!.name, value),
-    '优先级已更新',
+    t('优先级已更新', 'Priority updated'),
   )
   priorityDialog.show = false
 }
@@ -1403,9 +1432,9 @@ async function submitAccountConfirm() {
 
 function confirmEnableAccount(account: CodexKeeperAccount) {
   openAccountConfirm(
-    '启用账号',
-    `启用 ${account.name}？`,
-    '确认启用',
+    t('启用账号', 'Enable Account'),
+    t(`启用 ${account.name}？`, `Enable ${account.name}?`),
+    t('确认启用', 'Confirm Enable'),
     'primary',
     () => enableAccount(account),
   )
@@ -1413,9 +1442,9 @@ function confirmEnableAccount(account: CodexKeeperAccount) {
 
 function confirmDisableAccount(account: CodexKeeperAccount) {
   openAccountConfirm(
-    '禁用账号',
-    `禁用 ${account.name}？`,
-    '确认禁用',
+    t('禁用账号', 'Disable Account'),
+    t(`禁用 ${account.name}？`, `Disable ${account.name}?`),
+    t('确认禁用', 'Confirm Disable'),
     'warning',
     () => disableAccount(account),
   )
@@ -1423,9 +1452,9 @@ function confirmDisableAccount(account: CodexKeeperAccount) {
 
 function confirmDeleteAccount(account: CodexKeeperAccount) {
   openAccountConfirm(
-    '删除账号',
-    `删除 ${account.name}？此操作会从 CPA 删除 auth file。`,
-    '确认删除',
+    t('删除账号', 'Delete Account'),
+    t(`删除 ${account.name}？此操作会从 CPA 删除 auth file。`, `Delete ${account.name}? This will remove the auth file from CPA.`),
+    t('确认删除', 'Confirm Delete'),
     'error',
     () => deleteAccount(account),
   )
@@ -1436,7 +1465,7 @@ function enableAccount(account: CodexKeeperAccount) {
     account,
     'toggle',
     () => enableCodexKeeperAccount(account.name),
-    '账号已启用',
+    t('账号已启用', 'Account enabled'),
   )
 }
 
@@ -1445,7 +1474,7 @@ function disableAccount(account: CodexKeeperAccount) {
     account,
     'toggle',
     () => disableCodexKeeperAccount(account.name),
-    '账号已禁用',
+    t('账号已禁用', 'Account disabled'),
   )
 }
 
@@ -1454,7 +1483,7 @@ function deleteAccount(account: CodexKeeperAccount) {
     account,
     'delete',
     () => deleteCodexKeeperAccount(account.name),
-    '账号已删除',
+    t('账号已删除', 'Account deleted'),
   )
 }
 
@@ -1521,7 +1550,9 @@ async function refreshAccounts(
   }
   try {
     await refreshCodexKeeperAccounts({ auth_names: authNames })
-    message.success(authNames.length === 1 ? '已开始刷新账号' : `已开始刷新 ${authNames.length} 个账号`)
+    message.success(authNames.length === 1
+      ? t('已开始刷新账号', 'Started refreshing account')
+      : t(`已开始刷新 ${authNames.length} 个账号`, `Started refreshing ${authNames.length} accounts`))
     if (options.closeDetail) {
       detailOpen.value = false
     }
@@ -1530,7 +1561,7 @@ async function refreshAccounts(
     }
     void pollRefreshUntilIdle()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '刷新账号失败')
+    message.error(errorText(error, '刷新账号失败', 'Failed to refresh accounts'))
   } finally {
     const restActions = new Set(actingActions.value)
     refreshKeys.forEach((key) => restActions.delete(key))
@@ -1574,7 +1605,7 @@ async function runAccountAction(
       detailOpen.value = freshAccount !== null
     }
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '账号操作失败')
+    message.error(errorText(error, '账号操作失败', 'Account operation failed'))
   } finally {
     const nextActions = new Set(actingActions.value)
     nextActions.delete(key)
@@ -1582,56 +1613,58 @@ async function runAccountAction(
   }
 }
 
-const baseColumns: DataTableColumns<CodexKeeperAccount> = [
+const baseColumns = computed<DataTableColumns<CodexKeeperAccount>>(() => [
   {
-    title: '账号',
+    title: t('账号', 'Account'),
     key: 'identity',
     width: 360,
     render: (row) => renderAccountIdentityCell(row),
   },
   {
-    title: '类型',
+    title: t('类型', 'Type'),
     key: 'account_type',
     width: 96,
     render: (row) => renderAccountTypeCell(row),
   },
   {
-    title: '优先级',
+    title: t('优先级', 'Priority'),
     key: 'priority',
     width: 88,
     render: (row) => renderAccountPriorityCell(row),
   },
   {
-    title: '额度窗口',
+    title: t('额度窗口', 'Quota Window'),
     key: 'quota',
     width: 260,
     render: (row) => renderQuotaCell(row),
   },
   {
-    title: '窗口用量',
+    title: t('窗口用量', 'Window Usage'),
     key: 'quota_usage',
     width: 280,
     render: (row) => renderQuotaUsageCell(row),
   },
   {
-    title: '最近巡检',
+    title: t('最近巡检', 'Last Inspection'),
     key: 'last_checked_at',
     width: 150,
     render: (row) => renderLastCheckedCell(row),
   },
   {
-    title: '最近操作',
+    title: t('最近操作', 'Latest Action'),
     key: 'latest_action',
     width: 340,
     render: (row) => renderLatestActionCell(row),
   },
-]
+])
 
-const disabledBaseColumns: DataTableColumns<CodexKeeperAccount> = baseColumns.filter(
-  (column) => !('key' in column) || (column.key !== 'quota' && column.key !== 'quota_usage'),
+const disabledBaseColumns = computed<DataTableColumns<CodexKeeperAccount>>(
+  () => baseColumns.value.filter(
+    (column) => !('key' in column) || (column.key !== 'quota' && column.key !== 'quota_usage'),
+  ),
 )
 
-const disabledActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
+const disabledActionColumn = computed<DataTableColumns<CodexKeeperAccount>[number]>(() => ({
   title: '',
   key: 'actions',
   width: 224,
@@ -1645,7 +1678,7 @@ const disabledActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
           h(
             NButton,
             { size: 'small', quaternary: true, onClick: () => openDetail(row) },
-            { default: () => '详情' },
+            { default: () => t('详情', 'Details') },
           ),
           h(
             NButton,
@@ -1657,7 +1690,7 @@ const disabledActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
               loading: isActionLoading(row, 'toggle'),
               onClick: () => confirmEnableAccount(row),
             },
-            { default: () => '启用' },
+            { default: () => t('启用', 'Enable') },
           ),
           h(
             NButton,
@@ -1669,7 +1702,7 @@ const disabledActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
               loading: isActionLoading(row, 'delete'),
               onClick: () => confirmDeleteAccount(row),
             },
-            { default: () => '删除' },
+            { default: () => t('删除', 'Delete') },
           ),
           h(
             NButton,
@@ -1681,15 +1714,15 @@ const disabledActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
               loading: isActionLoading(row, 'refresh'),
               onClick: () => refreshAccount(row),
             },
-            { default: () => '刷新' },
+            { default: () => t('刷新', 'Refresh') },
           ),
         ],
       },
     )
   },
-}
+}))
 
-const normalActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
+const normalActionColumn = computed<DataTableColumns<CodexKeeperAccount>[number]>(() => ({
   title: '',
   key: 'actions',
   width: 232,
@@ -1703,7 +1736,7 @@ const normalActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
           h(
             NButton,
             { size: 'small', quaternary: true, onClick: () => openDetail(row) },
-            { default: () => '详情' },
+            { default: () => t('详情', 'Details') },
           ),
           h(
             NButton,
@@ -1715,7 +1748,7 @@ const normalActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
               loading: isActionLoading(row, 'toggle'),
               onClick: () => confirmDisableAccount(row),
             },
-            { default: () => '禁用' },
+            { default: () => t('禁用', 'Disable') },
           ),
           h(
             NButton,
@@ -1725,7 +1758,7 @@ const normalActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
               disabled: isRowActing(row) || isBulkDeleting.value || isBulkRefreshing.value,
               onClick: () => openPriorityDialog(row),
             },
-            { default: () => '优先级' },
+            { default: () => t('优先级', 'Priority') },
           ),
           h(
             NButton,
@@ -1737,13 +1770,13 @@ const normalActionColumn: DataTableColumns<CodexKeeperAccount>[number] = {
               loading: isActionLoading(row, 'refresh'),
               onClick: () => refreshAccount(row),
             },
-            { default: () => '刷新' },
+            { default: () => t('刷新', 'Refresh') },
           ),
         ],
       },
     )
   },
-}
+}))
 
 const disabledColumns = computed<DataTableColumns<CodexKeeperAccount>>(() => [
   {
@@ -1751,13 +1784,13 @@ const disabledColumns = computed<DataTableColumns<CodexKeeperAccount>>(() => [
     width: 44,
     disabled: (row: CodexKeeperAccount) => isRowActing(row) || isBulkDeleting.value,
   },
-  ...disabledBaseColumns,
-  disabledActionColumn,
+  ...disabledBaseColumns.value,
+  disabledActionColumn.value,
 ])
 
 const normalColumns = computed<DataTableColumns<CodexKeeperAccount>>(() => [
-  ...baseColumns,
-  normalActionColumn,
+  ...baseColumns.value,
+  normalActionColumn.value,
 ])
 
 restoreAccountStatusPreferences()
@@ -1806,17 +1839,17 @@ onBeforeUnmount(() => {
     <div class="page-header account-page-header">
       <div class="account-header-copy">
         <div class="account-header-title-row">
-          <h1 class="page-title">账号状态</h1>
+          <h1 class="page-title">{{ t('账号状态', 'Account Status') }}</h1>
           <div class="header-actions">
             <NButton secondary :loading="isLoading" @click="loadAccounts">
               <template #icon>
                 <NIcon :component="RefreshCw" />
               </template>
-              重新加载
+              {{ t('重新加载', 'Reload') }}
             </NButton>
           </div>
         </div>
-        <p class="page-subtitle">查看 Codex auth file 的健康、额度和优先级维护结果</p>
+        <p class="page-subtitle">{{ t('查看 Codex auth file 的健康、额度和优先级维护结果', 'View Codex auth file health, quota, and priority maintenance results') }}</p>
       </div>
     </div>
 
@@ -1825,7 +1858,7 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <Activity :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">运行状态</div>
+        <div class="metric-label">{{ t('运行状态', 'Run Status') }}</div>
         <div class="metric-value inspection-status-value" :title="keeperStatusDetailText">
           <NTag class="inspection-status-tag" :type="keeperStateType" size="small" :bordered="false">
             {{ keeperStatusDetailText }}
@@ -1837,9 +1870,9 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <Users :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">账号总数</div>
+        <div class="metric-label">{{ t('账号总数', 'Total Accounts') }}</div>
         <div class="metric-value">{{ formatInteger(accounts.length) }}</div>
-        <div class="metric-footnote">全部 auth file</div>
+        <div class="metric-footnote">{{ t('全部 auth file', 'All auth files') }}</div>
       </div>
       <button
         type="button"
@@ -1851,9 +1884,9 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <ShieldCheck :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">启用中</div>
+        <div class="metric-label">{{ t('启用中', 'Enabled') }}</div>
         <div class="metric-value">{{ formatInteger(enabledAccountCount) }}</div>
-        <div class="metric-footnote">可参与调度</div>
+        <div class="metric-footnote">{{ t('可参与调度', 'Available for scheduling') }}</div>
       </button>
       <button
         type="button"
@@ -1865,9 +1898,9 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <PauseCircle :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">已禁用</div>
+        <div class="metric-label">{{ t('已禁用', 'Disabled') }}</div>
         <div class="metric-value">{{ formatInteger(disabledAccountCount) }}</div>
-        <div class="metric-footnote">停用账号</div>
+        <div class="metric-footnote">{{ t('停用账号', 'Inactive accounts') }}</div>
       </button>
       <button
         type="button"
@@ -1879,7 +1912,7 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <ShieldAlert :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">401报错</div>
+        <div class="metric-label">{{ t('401报错', '401 Errors') }}</div>
         <div class="metric-value">{{ formatInteger(unauthorizedErrorAccountCount) }}</div>
         <div class="metric-footnote">HTTP 401</div>
       </button>
@@ -1893,9 +1926,9 @@ onBeforeUnmount(() => {
         <div class="metric-icon" aria-hidden="true">
           <Gauge :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">额度耗尽</div>
+        <div class="metric-label">{{ t('额度耗尽', 'Quota Exhausted') }}</div>
         <div class="metric-value">{{ formatInteger(quotaExhaustedAccountCount) }}</div>
-        <div class="metric-footnote">临时降级</div>
+        <div class="metric-footnote">{{ t('临时降级', 'Temporary downgrade') }}</div>
       </button>
     </div>
 
@@ -1903,26 +1936,26 @@ onBeforeUnmount(() => {
       <div class="status-toolbar">
         <div class="toolbar-heading">
           <div>
-            <h2 class="toolbar-title">账号列表</h2>
+            <h2 class="toolbar-title">{{ t('账号列表', 'Account List') }}</h2>
             <p class="toolbar-subtitle">
-              正常 {{ filteredNormalAccounts.length }} / {{ enabledAccountCount }} 个账号
+              {{ t(`正常 ${filteredNormalAccounts.length} / ${enabledAccountCount} 个账号`, `Normal ${filteredNormalAccounts.length} / ${enabledAccountCount} accounts`) }}
               <template v-if="hasDisabledAccounts">
-                ，已禁用 {{ filteredDisabledAccounts.length }} / {{ disabledAccountCount }} 个账号
+                {{ t(`，已禁用 ${filteredDisabledAccounts.length} / ${disabledAccountCount} 个账号`, `, disabled ${filteredDisabledAccounts.length} / ${disabledAccountCount} accounts`) }}
               </template>
             </p>
           </div>
           <NTag v-if="activeFilterCount > 0" size="small" type="info" :bordered="false">
-            已筛选 {{ activeFilterCount }} 项
+            {{ t(`已筛选 ${activeFilterCount} 项`, `${activeFilterCount} filters active`) }}
           </NTag>
         </div>
         <div class="filter-grid">
-          <NInput v-model:value="filters.keyword" clearable placeholder="搜索账号或邮箱" />
+          <NInput v-model:value="filters.keyword" clearable :placeholder="t('搜索账号或邮箱', 'Search account or email')" />
           <NSelect
             v-model:value="filters.accountType"
             :options="accountTypeOptions"
             clearable
             filterable
-            placeholder="账号类型"
+            :placeholder="t('账号类型', 'Account Type')"
           />
           <NSelect
             v-model:value="filters.priority"
@@ -1940,7 +1973,7 @@ onBeforeUnmount(() => {
                 <template #icon>
                   <NIcon :component="ChevronDown" />
                 </template>
-                切换样式：{{ accountListViewLabel }}
+                {{ t(`切换样式：${accountListViewLabel}`, `Switch View: ${accountListViewLabel}`) }}
               </NButton>
             </NDropdown>
             <NButton
@@ -1949,11 +1982,11 @@ onBeforeUnmount(() => {
               :type="refreshSelectMode ? 'primary' : 'default'"
               @click="toggleRefreshSelectMode"
             >
-              多选刷新
+              {{ t('多选刷新', 'Multi-select Refresh') }}
             </NButton>
             <template v-if="refreshSelectMode">
               <NTag size="small" type="info" :bordered="false">
-                {{ selectedRefreshCount }} 已选
+                {{ t(`${selectedRefreshCount} 已选`, `${selectedRefreshCount} selected`) }}
               </NTag>
               <NButton
                 secondary
@@ -1961,7 +1994,7 @@ onBeforeUnmount(() => {
                 :disabled="filteredAccountNames.length === 0 || isBulkRefreshing"
                 @click="selectAllFilteredRefreshAccounts"
               >
-                全选当前筛选
+                {{ t('全选当前筛选', 'Select Current Filter') }}
               </NButton>
               <NButton
                 secondary
@@ -1971,22 +2004,22 @@ onBeforeUnmount(() => {
                 :loading="isBulkRefreshing"
                 @click="refreshSelectedAccounts"
               >
-                刷新已选
+                {{ t('刷新已选', 'Refresh Selected') }}
               </NButton>
               <NButton secondary size="small" :disabled="isBulkRefreshing" @click="exitRefreshSelectMode">
-                退出选择
+                {{ t('退出选择', 'Exit Selection') }}
               </NButton>
             </template>
           </div>
-          <div class="sort-control-row" aria-label="账号排序">
-            <span class="sort-control-label">排序</span>
+          <div class="sort-control-row" :aria-label="t('账号排序', 'Account Sorting')">
+            <span class="sort-control-label">{{ t('排序', 'Sort') }}</span>
             <NDropdown trigger="click" :options="quotaSortOptions" @select="handleQuotaSortSelect">
               <NButton
                 secondary
                 size="small"
                 :type="accountSort.key === 'quotaDay' || accountSort.key === 'quotaWeek' ? 'primary' : 'default'"
               >
-                额度窗口{{ activeQuotaSortLabel ? `：${activeQuotaSortLabel} ${sortDirectionMark}` : '' }}
+                {{ activeQuotaSortLabel ? t(`额度窗口：${activeQuotaSortLabel} ${sortDirectionMark}`, `Quota Window: ${activeQuotaSortLabel} ${sortDirectionMark}`) : t('额度窗口', 'Quota Window') }}
               </NButton>
             </NDropdown>
             <NButton
@@ -1995,7 +2028,7 @@ onBeforeUnmount(() => {
               :type="isAccountSortActive('accountType') ? 'primary' : 'default'"
               @click="toggleAccountSort('accountType')"
             >
-              类型 {{ accountSortMark('accountType') }}
+              {{ t('类型', 'Type') }} {{ accountSortMark('accountType') }}
             </NButton>
             <NButton
               secondary
@@ -2003,7 +2036,7 @@ onBeforeUnmount(() => {
               :type="isAccountSortActive('status') ? 'primary' : 'default'"
               @click="toggleAccountSort('status')"
             >
-              状态 {{ accountSortMark('status') }}
+              {{ t('状态', 'Status') }} {{ accountSortMark('status') }}
             </NButton>
             <NButton
               secondary
@@ -2011,7 +2044,7 @@ onBeforeUnmount(() => {
               :type="isAccountSortActive('priority') ? 'primary' : 'default'"
               @click="toggleAccountSort('priority')"
             >
-              优先级 {{ accountSortMark('priority') }}
+              {{ t('优先级', 'Priority') }} {{ accountSortMark('priority') }}
             </NButton>
             <NButton
               secondary
@@ -2019,19 +2052,19 @@ onBeforeUnmount(() => {
               :type="isAccountSortActive('lastCheckedAt') ? 'primary' : 'default'"
               @click="toggleAccountSort('lastCheckedAt')"
             >
-              最近巡检 {{ accountSortMark('lastCheckedAt') }}
+              {{ t('最近巡检', 'Last Inspection') }} {{ accountSortMark('lastCheckedAt') }}
             </NButton>
           </div>
         </div>
       </div>
 
       <div v-if="isTableView" class="account-sections">
-        <div v-if="showTableLoadingState" class="empty-state">账号加载中...</div>
-        <div v-else-if="showEmptyTableState" class="empty-state">当前筛选下暂无账号</div>
+        <div v-if="showTableLoadingState" class="empty-state">{{ t('账号加载中...', 'Loading accounts...') }}</div>
+        <div v-else-if="showEmptyTableState" class="empty-state">{{ t('当前筛选下暂无账号', 'No accounts match the current filter') }}</div>
         <section v-if="showDisabledSection" class="account-section">
           <div class="account-section-header">
             <div class="account-section-title-group">
-              <h3 class="account-section-title">已禁用账号</h3>
+              <h3 class="account-section-title">{{ t('已禁用账号', 'Disabled Accounts') }}</h3>
               <p class="account-section-subtitle">
                 {{ disabledSectionDisplayText }}
               </p>
@@ -2047,7 +2080,7 @@ onBeforeUnmount(() => {
                 <template #icon>
                   <NIcon :component="Trash2" />
                 </template>
-                批量删除（{{ selectedDisabledCount }}）
+                {{ t(`批量删除（${selectedDisabledCount}）`, `Bulk Delete (${selectedDisabledCount})`) }}
               </NButton>
             </div>
           </div>
@@ -2067,7 +2100,7 @@ onBeforeUnmount(() => {
             @update:checked-row-keys="handleDisabledSelectionUpdate"
           >
             <template #empty>
-              <div class="empty-state">当前筛选下暂无已禁用账号</div>
+              <div class="empty-state">{{ t('当前筛选下暂无已禁用账号', 'No disabled accounts match the current filter') }}</div>
             </template>
           </NDataTable>
           <div v-if="showDisabledPagination" class="account-pagination-row">
@@ -2083,7 +2116,7 @@ onBeforeUnmount(() => {
         <section v-if="showNormalSection" class="account-section">
           <div class="account-section-header">
             <div class="account-section-title-group">
-              <h3 class="account-section-title">正常账号</h3>
+              <h3 class="account-section-title">{{ t('正常账号', 'Normal Accounts') }}</h3>
               <p class="account-section-subtitle">
                 {{ normalSectionDisplayText }}
               </p>
@@ -2103,7 +2136,7 @@ onBeforeUnmount(() => {
             :scroll-x="normalTableScrollX"
           >
             <template #empty>
-              <div class="empty-state">当前筛选下暂无正常账号</div>
+              <div class="empty-state">{{ t('当前筛选下暂无正常账号', 'No normal accounts match the current filter') }}</div>
             </template>
           </NDataTable>
           <div v-if="showNormalPagination" class="account-pagination-row">
@@ -2137,13 +2170,13 @@ onBeforeUnmount(() => {
                 <template #icon>
                   <NIcon :component="Trash2" />
                 </template>
-                批量删除 401 已禁用（{{ filteredUnauthorizedDisabledAccounts.length }}）
+                {{ t(`批量删除 401 已禁用（${filteredUnauthorizedDisabledAccounts.length}）`, `Bulk Delete 401 Disabled (${filteredUnauthorizedDisabledAccounts.length})`) }}
               </NButton>
             </div>
           </div>
-          <div v-if="showCardLoadingState" class="empty-state">账号加载中...</div>
+          <div v-if="showCardLoadingState" class="empty-state">{{ t('账号加载中...', 'Loading accounts...') }}</div>
           <div v-else-if="visibleCardAccounts.length === 0" class="empty-state">
-            当前筛选下暂无账号
+            {{ t('当前筛选下暂无账号', 'No accounts match the current filter') }}
           </div>
           <div
             v-else
@@ -2168,8 +2201,8 @@ onBeforeUnmount(() => {
               }"
               :aria-label="
                 refreshSelectMode
-                  ? `选择 ${account.email ?? account.name}`
-                  : `查看 ${account.email ?? account.name} 详情`
+                  ? t(`选择 ${account.email ?? account.name}`, `Select ${account.email ?? account.name}`)
+                  : t(`查看 ${account.email ?? account.name} 详情`, `View details for ${account.email ?? account.name}`)
               "
               :aria-pressed="refreshSelectMode ? isRefreshAccountSelected(account) : undefined"
               @click="handleAccountCardClick(account)"
@@ -2190,7 +2223,7 @@ onBeforeUnmount(() => {
                           : 'is-success'
                     "
                   >
-                    {{ account.disabled ? '已禁用' : isQuotaExhaustedAccount(account) ? '额度耗尽' : '启用中' }}
+                    {{ account.disabled ? t('已禁用', 'Disabled') : isQuotaExhaustedAccount(account) ? t('额度耗尽', 'Quota Exhausted') : t('启用中', 'Enabled') }}
                   </span>
                   <span
                     v-if="disabledStatusCodeText(account)"
@@ -2203,15 +2236,15 @@ onBeforeUnmount(() => {
               </div>
               <div class="account-card-meta-grid">
                 <div class="account-card-meta-item">
-                  <span>类型</span>
-                  <strong>{{ account.account_type ?? '未知' }}</strong>
+                  <span>{{ t('类型', 'Type') }}</span>
+                  <strong>{{ account.account_type ?? t('未知', 'Unknown') }}</strong>
                 </div>
                 <div class="account-card-meta-item">
-                  <span>优先级</span>
+                  <span>{{ t('优先级', 'Priority') }}</span>
                   <strong>{{ formatInteger(accountPriority(account)) }}</strong>
                 </div>
                 <div class="account-card-meta-item">
-                  <span>最近巡检</span>
+                  <span>{{ t('最近巡检', 'Last Inspection') }}</span>
                   <strong :title="formatDateTime(account.last_checked_at)">
                     {{ formatDateTime(account.last_checked_at, { includeSecond: false }) }}
                   </strong>
@@ -2222,7 +2255,7 @@ onBeforeUnmount(() => {
                 class="account-card-error"
                 :title="disabledCardErrorText(account)"
               >
-                <span>报错信息</span>
+                <span>{{ t('报错信息', 'Error Details') }}</span>
                 <strong>{{ disabledCardErrorText(account) }}</strong>
               </div>
               <div v-else-if="shouldShowQuotaWindow(account)" class="account-card-quota">
@@ -2235,7 +2268,7 @@ onBeforeUnmount(() => {
                     >
                       <div class="card-quota-head">
                         <span>{{ item.label }}</span>
-                        <strong>剩余 {{ item.remainingPercent }}%</strong>
+                        <strong>{{ t(`剩余 ${item.remainingPercent}%`, `${item.remainingPercent}% remaining`) }}</strong>
                       </div>
                       <div class="card-quota-track">
                         <div
@@ -2293,7 +2326,7 @@ onBeforeUnmount(() => {
                     </div>
                   </div>
                 </template>
-                <div v-else class="card-quota-empty">暂无额度窗口</div>
+                <div v-else class="card-quota-empty">{{ t('暂无额度窗口', 'No quota windows') }}</div>
               </div>
             </button>
           </div>
@@ -2310,7 +2343,7 @@ onBeforeUnmount(() => {
 
       <div class="display-control-row">
         <div class="display-control-copy">
-          <span class="display-control-label">每页数量</span>
+          <span class="display-control-label">{{ t('每页数量', 'Items Per Page') }}</span>
           <span class="display-control-help">{{ displaySizeHelpText }}</span>
         </div>
         <NSelect
@@ -2330,39 +2363,39 @@ onBeforeUnmount(() => {
               <template #icon>
                 <NIcon :component="ArrowLeft" />
               </template>
-              返回
+              {{ t('返回', 'Back') }}
             </NButton>
-            <span class="detail-drawer-title">账号详情</span>
+            <span class="detail-drawer-title">{{ t('账号详情', 'Account Details') }}</span>
           </div>
         </template>
         <NDescriptions v-if="selectedAccount" label-placement="left" :column="1" size="small" bordered>
-          <NDescriptionsItem label="账号">{{ selectedAccount.name }}</NDescriptionsItem>
-          <NDescriptionsItem label="邮箱">{{ selectedAccount.email ?? '-' }}</NDescriptionsItem>
-          <NDescriptionsItem label="账号类型">
-            {{ selectedAccount.account_type ?? '未知' }}
+          <NDescriptionsItem :label="t('账号', 'Account')">{{ selectedAccount.name }}</NDescriptionsItem>
+          <NDescriptionsItem :label="t('邮箱', 'Email')">{{ selectedAccount.email ?? '-' }}</NDescriptionsItem>
+          <NDescriptionsItem :label="t('账号类型', 'Account Type')">
+            {{ selectedAccount.account_type ?? t('未知', 'Unknown') }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="启用状态">
-            {{ selectedAccount.disabled ? '已禁用' : '启用中' }}
+          <NDescriptionsItem :label="t('启用状态', 'Enabled Status')">
+            {{ selectedAccount.disabled ? t('已禁用', 'Disabled') : t('启用中', 'Enabled') }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="当前优先级">
+          <NDescriptionsItem :label="t('当前优先级', 'Current Priority')">
             {{ accountPriority(selectedAccount) }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="类型默认优先级">
+          <NDescriptionsItem :label="t('类型默认优先级', 'Type Default Priority')">
             {{ defaultPriority(selectedAccount) ?? '-' }}
           </NDescriptionsItem>
-          <NDescriptionsItem v-if="shouldShowQuotaWindow(selectedAccount)" label="额度窗口">
+          <NDescriptionsItem v-if="shouldShowQuotaWindow(selectedAccount)" :label="t('额度窗口', 'Quota Window')">
             {{ quotaText(selectedAccount) }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="状态码">
+          <NDescriptionsItem :label="t('状态码', 'Status Code')">
             {{ selectedAccount.last_status_code ?? '-' }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="最近健康">
+          <NDescriptionsItem :label="t('最近健康', 'Last Healthy')">
             {{ formatDateTime(selectedAccount.last_healthy_at) }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="最近巡检">
+          <NDescriptionsItem :label="t('最近巡检', 'Last Inspection')">
             {{ formatDateTime(selectedAccount.last_checked_at) }}
           </NDescriptionsItem>
-          <NDescriptionsItem label="最近操作">
+          <NDescriptionsItem :label="t('最近操作', 'Latest Action')">
             {{ latestActionText(selectedAccount) }}
           </NDescriptionsItem>
         </NDescriptions>
@@ -2376,7 +2409,7 @@ onBeforeUnmount(() => {
               :loading="isActionLoading(selectedAccount, 'refresh')"
               @click="refreshAccount(selectedAccount, { closeDetail: true })"
             >
-              刷新
+              {{ t('刷新', 'Refresh') }}
             </NButton>
             <NButton
               v-if="selectedAccount.disabled"
@@ -2387,7 +2420,7 @@ onBeforeUnmount(() => {
               :loading="isActionLoading(selectedAccount, 'toggle')"
               @click="confirmEnableAccount(selectedAccount)"
             >
-              启用
+              {{ t('启用', 'Enable') }}
             </NButton>
             <NButton
               v-else
@@ -2398,7 +2431,7 @@ onBeforeUnmount(() => {
               :loading="isActionLoading(selectedAccount, 'toggle')"
               @click="confirmDisableAccount(selectedAccount)"
             >
-              禁用
+              {{ t('禁用', 'Disable') }}
             </NButton>
             <NButton
               size="small"
@@ -2407,7 +2440,7 @@ onBeforeUnmount(() => {
               :loading="isActionLoading(selectedAccount, 'priority')"
               @click="openPriorityDialog(selectedAccount)"
             >
-              修改优先级
+              {{ t('修改优先级', 'Change Priority') }}
             </NButton>
             <NButton
               v-if="selectedAccount.disabled"
@@ -2418,7 +2451,7 @@ onBeforeUnmount(() => {
               :loading="isActionLoading(selectedAccount, 'delete')"
               @click="confirmDeleteAccount(selectedAccount)"
             >
-              删除
+              {{ t('删除', 'Delete') }}
             </NButton>
           </NSpace>
         </div>
@@ -2435,7 +2468,7 @@ onBeforeUnmount(() => {
       <template #action>
         <NSpace justify="end">
           <NButton :disabled="isAccountConfirmSubmitting" @click="accountConfirmDialog.show = false">
-            取消
+            {{ t('取消', 'Cancel') }}
           </NButton>
           <NButton
             :type="accountConfirmDialog.type"
@@ -2460,19 +2493,19 @@ onBeforeUnmount(() => {
         </p>
         <div v-if="bulkDeletePreviewNames.length > 0" class="bulk-delete-preview">
           <span v-for="name in bulkDeletePreviewNames" :key="name">{{ name }}</span>
-          <span v-if="bulkDeletePreviewOverflow > 0">另 {{ bulkDeletePreviewOverflow }} 个...</span>
+          <span v-if="bulkDeletePreviewOverflow > 0">{{ t(`另 ${bulkDeletePreviewOverflow} 个...`, `${bulkDeletePreviewOverflow} more...`) }}</span>
         </div>
       </div>
       <template #action>
         <NSpace justify="end">
-          <NButton :disabled="isBulkDeleting" @click="bulkDeleteDialog.show = false">取消</NButton>
+          <NButton :disabled="isBulkDeleting" @click="bulkDeleteDialog.show = false">{{ t('取消', 'Cancel') }}</NButton>
           <NButton
             type="error"
             :disabled="selectedDisabledCount === 0"
             :loading="isBulkDeleting"
             @click="submitBulkDelete"
           >
-            确认删除
+            {{ t('确认删除', 'Confirm Delete') }}
           </NButton>
         </NSpace>
       </template>
@@ -2500,7 +2533,7 @@ onBeforeUnmount(() => {
       </div>
       <template #action>
         <NSpace justify="end">
-          <NButton @click="priorityDialog.show = false">取消</NButton>
+          <NButton @click="priorityDialog.show = false">{{ t('取消', 'Cancel') }}</NButton>
           <NButton
             type="primary"
             :disabled="!canSubmitPriority"
@@ -2511,7 +2544,7 @@ onBeforeUnmount(() => {
             "
             @click="submitPriorityDialog"
           >
-            确认
+            {{ t('确认', 'Confirm') }}
           </NButton>
         </NSpace>
       </template>

--- a/frontend/src/features/models/views/AvailableModelsView.vue
+++ b/frontend/src/features/models/views/AvailableModelsView.vue
@@ -15,6 +15,7 @@ import {
 import { Cpu, KeyRound, RefreshCw, ShieldCheck } from 'lucide-vue-next'
 
 import { listAvailableModels } from '@/features/models/api/availableModelsApi'
+import { useI18n } from '@/shared/i18n'
 import type { AvailableModel, AvailableModelPrice, AvailableModelsResponse } from '@/shared/types/api'
 
 type PriceField = keyof Pick<
@@ -27,6 +28,7 @@ type PriceField = keyof Pick<
 type BillingUnit = 'token' | 'request'
 
 const router = useRouter()
+const { currentLanguage, errorText, serverText, t } = useI18n()
 const isLoading = ref(false)
 const errorMessage = ref<string | null>(null)
 const response = ref<AvailableModelsResponse | null>(null)
@@ -43,12 +45,12 @@ const queryStatus = computed(() => {
     return '-'
   }
   if (response.value.errors.length > 0) {
-    return `部分失败 ${response.value.errors.length}`
+    return t(`部分失败 ${response.value.errors.length}`, `${response.value.errors.length} failed`)
   }
   if (response.value.queryable_api_key_count === 0) {
-    return response.value.has_api_keys ? '不可查询' : '无 Key'
+    return response.value.has_api_keys ? t('不可查询', 'Unavailable') : t('无 Key', 'No keys')
   }
-  return response.value.has_api_keys ? '正常' : '无 Key'
+  return response.value.has_api_keys ? t('正常', 'Normal') : t('无 Key', 'No keys')
 })
 
 function displayText(value: string | null | undefined): string {
@@ -56,7 +58,7 @@ function displayText(value: string | null | undefined): string {
 }
 
 function formatUsdPerMtok(value: number): string {
-  return value.toLocaleString('en-US', {
+  return value.toLocaleString(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     maximumFractionDigits: 6,
   })
 }
@@ -94,7 +96,7 @@ function renderBillingUnit(row: AvailableModel) {
         lineHeight: '1.2',
       },
     },
-    isRequest ? '按次' : '按 Token',
+    isRequest ? t('按次', 'Per request') : t('按 Token', 'Per token'),
   )
 }
 
@@ -103,7 +105,7 @@ function renderRequestPrice(row: AvailableModel) {
     return h('span', { class: 'model-price-muted' }, '-')
   }
   if (row.price?.request_usd === null || row.price?.request_usd === undefined) {
-    return h('span', { class: 'model-price-muted' }, '未定价')
+    return h('span', { class: 'model-price-muted' }, t('未定价', 'Unpriced'))
   }
   return formatUsdPerMtok(row.price.request_usd)
 }
@@ -129,35 +131,35 @@ async function refresh() {
     response.value = await listAvailableModels()
   } catch (error) {
     response.value = null
-    errorMessage.value = error instanceof Error ? error.message : '加载可用模型失败'
+    errorMessage.value = errorText(error, '加载可用模型失败', 'Failed to load available models')
   } finally {
     isLoading.value = false
   }
 }
 
-const columns: DataTableColumns<AvailableModel> = [
+const columns = computed<DataTableColumns<AvailableModel>>(() => [
   {
-    title: '模型 ID',
+    title: t('模型 ID', 'Model ID'),
     key: 'id',
     width: 270,
     ellipsis: { tooltip: true },
     render: (row) => h('span', { class: 'model-id' }, row.id),
   },
   {
-    title: '名称',
+    title: t('名称', 'Name'),
     key: 'name',
     width: 220,
     ellipsis: { tooltip: true },
     render: (row) => displayText(row.name),
   },
   {
-    title: 'Owner',
+    title: t('所有者', 'Owner'),
     key: 'owner',
     width: 150,
     render: (row) => displayText(row.owner),
   },
   {
-    title: '来源 Key',
+    title: t('来源 Key', 'Source Key'),
     key: 'sources',
     width: 220,
     render: (row) =>
@@ -177,42 +179,42 @@ const columns: DataTableColumns<AvailableModel> = [
       ),
   },
   {
-    title: '计费方式',
+    title: t('计费方式', 'Billing'),
     key: 'billing_unit',
     width: 110,
     render: renderBillingUnit,
   },
   {
-    title: '每次 ($)',
+    title: t('每次 ($)', 'Per request ($)'),
     key: 'request_usd',
     width: 110,
     render: renderRequestPrice,
   },
   {
-    title: '输入 ($/MTok)',
+    title: t('输入 ($/MTok)', 'Input ($/MTok)'),
     key: 'input_usd_per_million',
     width: 145,
     render: (row) => renderPriceValue(row, 'input_usd_per_million'),
   },
   {
-    title: '输出 ($/MTok)',
+    title: t('输出 ($/MTok)', 'Output ($/MTok)'),
     key: 'output_usd_per_million',
     width: 145,
     render: (row) => renderPriceValue(row, 'output_usd_per_million'),
   },
   {
-    title: '缓存读 ($/MTok)',
+    title: t('缓存读 ($/MTok)', 'Cache read ($/MTok)'),
     key: 'cache_read_usd_per_million',
     width: 145,
     render: (row) => renderPriceValue(row, 'cache_read_usd_per_million'),
   },
   {
-    title: '缓存写 ($/MTok)',
+    title: t('缓存写 ($/MTok)', 'Cache write ($/MTok)'),
     key: 'cache_creation_usd_per_million',
     width: 145,
     render: (row) => renderPriceValue(row, 'cache_creation_usd_per_million'),
   },
-]
+])
 
 onMounted(refresh)
 </script>
@@ -221,15 +223,15 @@ onMounted(refresh)
   <section class="page models-page" :aria-busy="isLoading">
     <div class="page-header">
       <div>
-        <h1 class="page-title">可用模型</h1>
-        <p class="page-subtitle">通过当前账号绑定的 CPA API Key 查询并聚合</p>
+        <h1 class="page-title">{{ t('可用模型', 'Available Models') }}</h1>
+        <p class="page-subtitle">{{ t('通过当前账号绑定的 CPA API Key 查询并聚合', 'Query and aggregate models from CPA API keys bound to the current account') }}</p>
       </div>
       <NSpace>
         <NButton secondary :loading="isLoading" @click="refresh">
           <template #icon>
             <NIcon :component="RefreshCw" />
           </template>
-          刷新
+          {{ t('刷新', 'Refresh') }}
         </NButton>
       </NSpace>
     </div>
@@ -239,7 +241,7 @@ onMounted(refresh)
         <NAlert v-if="errorMessage" type="error" :bordered="false">
           <div class="alert-row">
             <span>{{ errorMessage }}</span>
-            <NButton size="small" secondary :loading="isLoading" @click="refresh">重试</NButton>
+            <NButton size="small" secondary :loading="isLoading" @click="refresh">{{ t('重试', 'Retry') }}</NButton>
           </div>
         </NAlert>
 
@@ -248,11 +250,16 @@ onMounted(refresh)
             v-if="response?.errors.length"
             type="warning"
             :bordered="false"
-            title="部分 API Key 查询失败"
+            :title="t('部分 API Key 查询失败', 'Some API key queries failed')"
           >
             <div class="key-errors">
               <div v-for="error in response.errors" :key="error.api_key_hash">
-                {{ error.description }}（{{ error.api_key_preview }}）：{{ error.message }}
+                {{
+                  t(
+                    `${error.description}（${error.api_key_preview}）：${serverText(error.message, '查询失败', 'Query failed')}`,
+                    `${error.description} (${error.api_key_preview}): ${serverText(error.message, '查询失败', 'Query failed')}`,
+                  )
+                }}
               </div>
             </div>
           </NAlert>
@@ -262,37 +269,37 @@ onMounted(refresh)
               <div class="metric-icon" aria-hidden="true">
                 <Cpu :size="20" :stroke-width="2.2" />
               </div>
-              <div class="metric-label">可用模型</div>
+              <div class="metric-label">{{ t('可用模型', 'Available models') }}</div>
               <div class="metric-value">{{ modelCount }}</div>
-              <div class="metric-footnote">CPA 返回</div>
+              <div class="metric-footnote">{{ t('CPA 返回', 'Returned by CPA') }}</div>
             </div>
             <div class="metric-card is-blue">
               <div class="metric-icon" aria-hidden="true">
                 <KeyRound :size="20" :stroke-width="2.2" />
               </div>
-              <div class="metric-label">可查询 Key</div>
+              <div class="metric-label">{{ t('可查询 Key', 'Queryable keys') }}</div>
               <div class="metric-value">{{ keySummary }}</div>
-              <div class="metric-footnote">完整密钥</div>
+              <div class="metric-footnote">{{ t('完整密钥', 'Complete keys') }}</div>
             </div>
             <div class="metric-card is-green">
               <div class="metric-icon" aria-hidden="true">
                 <ShieldCheck :size="20" :stroke-width="2.2" />
               </div>
-              <div class="metric-label">查询状态</div>
+              <div class="metric-label">{{ t('查询状态', 'Query status') }}</div>
               <div class="metric-value">{{ queryStatus }}</div>
-              <div class="metric-footnote">当前账号</div>
+              <div class="metric-footnote">{{ t('当前账号', 'Current account') }}</div>
             </div>
           </div>
 
           <div v-if="isLoading && !response" class="loading-state">
             <NSpin size="small" />
-            <span>正在向 CPA 查询模型</span>
+            <span>{{ t('正在向 CPA 查询模型', 'Querying CPA for models') }}</span>
           </div>
 
           <div v-else-if="response && !response.has_api_keys" class="empty-state">
-            <NEmpty description="还没有可用于查询模型的 API 密钥">
+            <NEmpty :description="t('还没有可用于查询模型的 API 密钥', 'No API keys are available for model queries yet')">
               <template #extra>
-                <NButton type="primary" @click="goToApiKeys">去创建 API 密钥</NButton>
+                <NButton type="primary" @click="goToApiKeys">{{ t('去创建 API 密钥', 'Create API key') }}</NButton>
               </template>
             </NEmpty>
           </div>
@@ -301,17 +308,17 @@ onMounted(refresh)
             v-else-if="response && response.has_api_keys && response.queryable_api_key_count === 0"
             class="empty-state"
           >
-            <NEmpty description="绑定的 API 密钥缺少完整密钥，无法查询模型">
+            <NEmpty :description="t('绑定的 API 密钥缺少完整密钥，无法查询模型', 'Bound API keys are missing complete keys and cannot query models')">
               <template #extra>
-                <NButton type="primary" @click="goToApiKeys">去 API 密钥页检查</NButton>
+                <NButton type="primary" @click="goToApiKeys">{{ t('去 API 密钥页检查', 'Check API keys') }}</NButton>
               </template>
             </NEmpty>
           </div>
 
           <div v-else-if="response && response.models.length === 0" class="empty-state">
-            <NEmpty description="CPA 未返回可用模型">
+            <NEmpty :description="t('CPA 未返回可用模型', 'CPA returned no available models')">
               <template #extra>
-                <NButton secondary :loading="isLoading" @click="refresh">重新查询</NButton>
+                <NButton secondary :loading="isLoading" @click="refresh">{{ t('重新查询', 'Query again') }}</NButton>
               </template>
             </NEmpty>
           </div>

--- a/frontend/src/features/pricing/views/ModelPricesView.vue
+++ b/frontend/src/features/pricing/views/ModelPricesView.vue
@@ -38,6 +38,7 @@ import type {
   ModelPricePayload,
 } from '@/shared/types/api'
 import { formatDateTime, formatInteger } from '@/shared/utils/format'
+import { useI18n } from '@/shared/i18n'
 
 type PriceTableLayoutProps =
   | { flexHeight: true }
@@ -73,11 +74,10 @@ const priceModalStyle: CSSProperties = { width: 'min(640px, calc(100vw - 32px))'
 const proxyModalStyle: CSSProperties = { width: 'min(460px, calc(100vw - 32px))' }
 const proxyModalContentStyle: CSSProperties = { padding: '16px 22px 4px' }
 const proxyModalFooterStyle: CSSProperties = { padding: '12px 22px 18px' }
-const liteLLMProxyHint =
-  'LiteLLM 价格数据从 GitHub 下载；如果当前网络无法访问 GitHub，可以启用代理后再同步。'
 const desktopPriceLayoutQuery = window.matchMedia('(min-width: 861px)')
 const message = useMessage()
 const dialog = useDialog()
+const { errorText, serverText, t } = useI18n()
 const isLoading = ref(false)
 const isSyncing = ref(false)
 const modalOpen = ref(false)
@@ -160,13 +160,20 @@ const providerOptions = computed(() =>
     .map((provider) => ({ label: provider, value: provider })),
 )
 
-const statusOptions: Array<{ label: string; value: PriceStatusFilter }> = [
-  { label: 'CPA 可用模型', value: 'cpa' },
-  { label: '未定价', value: 'missing' },
+const liteLLMProxyHint = computed(() =>
+  t(
+    'LiteLLM 价格数据从 GitHub 下载；如果当前网络无法访问 GitHub，可以启用代理后再同步。',
+    'LiteLLM price data is downloaded from GitHub. If GitHub is not reachable from this network, enable a proxy and sync again.',
+  ),
+)
+
+const statusOptions = computed<Array<{ label: string; value: PriceStatusFilter }>>(() => [
+  { label: t('CPA 可用模型', 'CPA available models'), value: 'cpa' },
+  { label: t('未定价', 'Unpriced'), value: 'missing' },
   { label: 'LiteLLM', value: 'litellm' },
-  { label: '手动', value: 'manual' },
-  { label: '仅有价格', value: 'library' },
-]
+  { label: t('手动', 'Manual'), value: 'manual' },
+  { label: t('仅有价格', 'Prices only'), value: 'library' },
+])
 
 const filteredPrices = computed(() => {
   return priceRows.value.filter((row) => {
@@ -254,17 +261,25 @@ const catalogNotice = computed(() => {
     return ''
   }
   if (!current.has_api_keys) {
-    return '还没有本地绑定的 API Key，当前只显示已有价格库条目。'
+    return t('还没有本地绑定的 API Key，当前只显示已有价格库条目。', 'No local API keys are bound yet. Only existing price library entries are shown.')
   }
   if (current.queryable_api_key_count === 0) {
-    return '本地 API Key 没有保存明文 Key，暂时无法查询 CPA 当前模型，只显示已有价格库条目。'
+    return t(
+      '本地 API Key 没有保存明文 Key，暂时无法查询 CPA 当前模型，只显示已有价格库条目。',
+      'Local API keys do not store plaintext keys, so CPA models cannot be queried for now. Only existing price library entries are shown.',
+    )
   }
   if (current.errors.length > 0) {
     const details = current.errors
       .slice(0, 3)
-      .map((item) => `${item.description}：${item.message}`)
-      .join('；')
-    return `部分 Key 查询 CPA 模型失败：${details}`
+      .map((item) =>
+        t(
+          `${item.description}：${serverText(item.message, '查询失败', 'Query failed')}`,
+          `${item.description}: ${serverText(item.message, '查询失败', 'Query failed')}`,
+        ),
+      )
+      .join(t('；', '; '))
+    return t(`部分 Key 查询 CPA 模型失败：${details}`, `Some keys failed to query CPA models: ${details}`)
   }
   return ''
 })
@@ -276,8 +291,14 @@ const priceTableLayoutProps = computed<PriceTableLayoutProps>(() =>
 const isRequestPriceForm = computed(() => billingUnitForModel(form.model) === 'request')
 const priceSaveHint = computed(() =>
   isRequestPriceForm.value
-    ? 'image 模型按每次成功调用固定金额计费，保存后会作为手动价格优先保留。'
-    : '保存后会作为手动价格，后续 LiteLLM 同步会优先保留。',
+    ? t(
+        'image 模型按每次成功调用固定金额计费，保存后会作为手动价格优先保留。',
+        'Image models are charged a fixed amount per successful call. Saved values are kept as manual prices with priority.',
+      )
+    : t(
+        '保存后会作为手动价格，后续 LiteLLM 同步会优先保留。',
+        'Saved values are kept as manual prices and preserved by later LiteLLM syncs.',
+      ),
 )
 
 interface PriceMetricCard {
@@ -292,35 +313,41 @@ interface PriceMetricCard {
 const priceMetrics = computed<PriceMetricCard[]>(() => [
   {
     key: 'models',
-    label: 'CPA 模型',
+    label: t('CPA 模型', 'CPA models'),
     value: formatInteger(cpaModelCount.value),
     footnote: catalog.value
-      ? `可查询 Key ${formatInteger(catalog.value.queryable_api_key_count)} / ${formatInteger(catalog.value.api_key_count)}`
-      : '等待刷新',
+      ? t(
+          `可查询 Key ${formatInteger(catalog.value.queryable_api_key_count)} / ${formatInteger(catalog.value.api_key_count)}`,
+          `Queryable keys ${formatInteger(catalog.value.queryable_api_key_count)} / ${formatInteger(catalog.value.api_key_count)}`,
+        )
+      : t('等待刷新', 'Waiting for refresh'),
     tone: 'teal',
     icon: Layers3,
   },
   {
     key: 'unpriced',
-    label: '未定价',
+    label: t('未定价', 'Unpriced'),
     value: formatInteger(unpricedModelCount.value),
-    footnote: `筛选后 ${formatInteger(filteredPriceCount.value)} / ${formatInteger(totalPriceCount.value)}`,
+    footnote: t(
+      `筛选后 ${formatInteger(filteredPriceCount.value)} / ${formatInteger(totalPriceCount.value)}`,
+      `Filtered ${formatInteger(filteredPriceCount.value)} / ${formatInteger(totalPriceCount.value)}`,
+    ),
     tone: 'blue',
     icon: Server,
   },
   {
     key: 'synced',
-    label: 'LiteLLM 同步',
+    label: t('LiteLLM 同步', 'LiteLLM sync'),
     value: formatInteger(syncedPriceCount.value),
-    footnote: '自动维护',
+    footnote: t('自动维护', 'Auto maintained'),
     tone: 'purple',
     icon: RefreshCw,
   },
   {
     key: 'manual',
-    label: '手动价格',
+    label: t('手动价格', 'Manual prices'),
     value: formatInteger(manualPriceCount.value),
-    footnote: '优先保留',
+    footnote: t('优先保留', 'Preserved first'),
     tone: 'orange',
     icon: Database,
   },
@@ -358,7 +385,7 @@ async function refresh() {
     prices.value = nextPrices
     catalog.value = nextCatalog
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载模型价格失败')
+    message.error(errorText(error, '加载模型价格失败', 'Failed to load model prices'))
   } finally {
     isLoading.value = false
   }
@@ -408,25 +435,25 @@ async function savePrice() {
     request_usd: requestUSD,
   }
   if (!payload.provider || !payload.model) {
-    message.error('服务商和模型不能为空')
+    message.error(t('服务商和模型不能为空', 'Provider and model are required'))
     return
   }
   if (requestPriceMode && requestUSD === null) {
-    message.error('image 模型需要填写每次调用价格')
+    message.error(t('image 模型需要填写每次调用价格', 'Image models require a per-call price'))
     return
   }
   try {
     if (editingId.value === null) {
       await createModelPrice(payload)
-      message.success('模型价格已创建')
+      message.success(t('模型价格已创建', 'Model price created'))
     } else {
       await updateModelPrice(editingId.value, payload)
-      message.success('模型价格已更新')
+      message.success(t('模型价格已更新', 'Model price updated'))
     }
     modalOpen.value = false
     await refresh()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '保存模型价格失败')
+    message.error(errorText(error, '保存模型价格失败', 'Failed to save model price'))
   }
 }
 
@@ -435,12 +462,15 @@ async function syncPrices() {
   try {
     const result = await syncLitellmModelPrices()
     message.success(
-      `同步完成：LiteLLM 价格 ${result.imported} 条，手动价格保留 ${result.skipped_manual} 条`,
+      t(
+        `同步完成：LiteLLM 价格 ${result.imported} 条，手动价格保留 ${result.skipped_manual} 条`,
+        `Sync complete: ${result.imported} LiteLLM prices imported, ${result.skipped_manual} manual prices preserved`,
+      ),
     )
     await refresh()
   } catch (error) {
-    const detail = error instanceof Error ? error.message : '同步模型价格失败'
-    message.error(`${detail}。${liteLLMProxyHint}`)
+    const detail = errorText(error, '同步模型价格失败', 'Failed to sync model prices')
+    message.error(t(`${detail}。${liteLLMProxyHint.value}`, `${detail}. ${liteLLMProxyHint.value}`))
   } finally {
     isSyncing.value = false
   }
@@ -454,7 +484,7 @@ async function openProxySettings() {
     proxyForm.enabled = settings.enabled
     proxyForm.proxy_url = settings.proxy_url
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载代理配置失败')
+    message.error(errorText(error, '加载代理配置失败', 'Failed to load proxy settings'))
   } finally {
     isProxyLoading.value = false
   }
@@ -466,7 +496,7 @@ async function saveProxySettings() {
     proxy_url: proxyForm.proxy_url.trim(),
   }
   if (payload.enabled && !payload.proxy_url) {
-    message.error('启用代理时必须填写代理地址')
+    message.error(t('启用代理时必须填写代理地址', 'Proxy URL is required when proxy is enabled'))
     return
   }
   isProxySaving.value = true
@@ -475,9 +505,9 @@ async function saveProxySettings() {
     proxyForm.enabled = saved.enabled
     proxyForm.proxy_url = saved.proxy_url
     proxyModalOpen.value = false
-    message.success('代理配置已保存')
+    message.success(t('代理配置已保存', 'Proxy settings saved'))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '保存代理配置失败')
+    message.error(errorText(error, '保存代理配置失败', 'Failed to save proxy settings'))
   } finally {
     isProxySaving.value = false
   }
@@ -485,13 +515,13 @@ async function saveProxySettings() {
 
 function confirmDelete(row: ModelPrice) {
   dialog.warning({
-    title: '删除价格',
+    title: t('删除价格', 'Delete price'),
     content: `${row.provider} / ${row.model}`,
-    positiveText: '删除',
-    negativeText: '取消',
+    positiveText: t('删除', 'Delete'),
+    negativeText: t('取消', 'Cancel'),
     onPositiveClick: async () => {
       await deleteModelPrice(row.id)
-      message.success('模型价格已删除')
+      message.success(t('模型价格已删除', 'Model price deleted'))
       await refresh()
     },
   })
@@ -527,7 +557,7 @@ function renderBillingUnitCell(row: PriceDisplayRow) {
         lineHeight: '1.2',
       },
     },
-    isRequest ? '按次' : '按 Token',
+    isRequest ? t('按次', 'Per call') : t('按 Token', 'Per token'),
   )
 }
 
@@ -543,7 +573,7 @@ function renderRequestPriceValue(row: PriceDisplayRow) {
     return h('span', { class: 'price-muted' }, '-')
   }
   if (row.price?.request_usd === null || row.price?.request_usd === undefined) {
-    return h('span', { class: 'price-muted' }, '未定价')
+    return h('span', { class: 'price-muted' }, t('未定价', 'Unpriced'))
   }
   return formatPriceValue(row.price.request_usd)
 }
@@ -562,7 +592,7 @@ function renderModelCell(row: PriceDisplayRow) {
               bordered: false,
               style: { marginLeft: '16px' },
             },
-            { default: () => 'CPA 可用模型' },
+            { default: () => t('CPA 可用模型', 'CPA available model') },
           )
         : null,
     ]),
@@ -573,12 +603,14 @@ function renderModelCell(row: PriceDisplayRow) {
 function renderProviderCell(row: PriceDisplayRow) {
   return h('div', { class: 'provider-cell' }, [
     h('div', { class: 'provider-main' }, row.provider || '-'),
-    row.owner && row.owner !== row.provider ? h('div', { class: 'model-sub' }, `Owner: ${row.owner}`) : null,
+    row.owner && row.owner !== row.provider
+      ? h('div', { class: 'model-sub' }, t('所有者', 'Owner') + `: ${row.owner}`)
+      : null,
   ])
 }
 
 function renderStatusCell(row: PriceDisplayRow) {
-  const label = row.status === 'missing' ? '未定价' : row.status === 'litellm' ? 'LiteLLM' : '手动'
+  const label = row.status === 'missing' ? t('未定价', 'Unpriced') : row.status === 'litellm' ? 'LiteLLM' : t('手动', 'Manual')
   const type = row.status === 'missing' ? 'warning' : row.status === 'litellm' ? 'info' : 'default'
   return h(
     NTag,
@@ -587,65 +619,65 @@ function renderStatusCell(row: PriceDisplayRow) {
   )
 }
 
-const columns: DataTableColumns<PriceDisplayRow> = [
+const columns = computed<DataTableColumns<PriceDisplayRow>>(() => [
   {
-    title: '模型',
+    title: t('模型', 'Model'),
     key: 'id',
     width: 380,
     ellipsis: { tooltip: true },
     render: renderModelCell,
   },
   {
-    title: '服务商',
+    title: t('服务商', 'Provider'),
     key: 'provider',
     width: 160,
     ellipsis: { tooltip: true },
     render: renderProviderCell,
   },
   {
-    title: '定价',
+    title: t('定价', 'Pricing'),
     key: 'status',
     width: 96,
     render: renderStatusCell,
   },
   {
-    title: '计费方式',
+    title: t('计费方式', 'Billing'),
     key: 'billing_unit',
     width: 100,
     render: renderBillingUnitCell,
   },
   {
-    title: '每次 ($)',
+    title: t('每次 ($)', 'Per call ($)'),
     key: 'request_usd',
     width: 110,
     render: renderRequestPriceValue,
   },
   {
-    title: '输入 ($/MTok)',
+    title: t('输入 ($/MTok)', 'Input ($/MTok)'),
     key: 'input_usd_per_million',
     width: 125,
     render: (row) => renderTokenPriceValue(row, 'input_usd_per_million'),
   },
   {
-    title: '输出 ($/MTok)',
+    title: t('输出 ($/MTok)', 'Output ($/MTok)'),
     key: 'output_usd_per_million',
     width: 125,
     render: (row) => renderTokenPriceValue(row, 'output_usd_per_million'),
   },
   {
-    title: '缓存读 ($/MTok)',
+    title: t('缓存读 ($/MTok)', 'Cache read ($/MTok)'),
     key: 'cache_read_usd_per_million',
     width: 125,
     render: (row) => renderTokenPriceValue(row, 'cache_read_usd_per_million'),
   },
   {
-    title: '缓存写 ($/MTok)',
+    title: t('缓存写 ($/MTok)', 'Cache write ($/MTok)'),
     key: 'cache_creation_usd_per_million',
     width: 125,
     render: (row) => renderTokenPriceValue(row, 'cache_creation_usd_per_million'),
   },
   {
-    title: '更新',
+    title: t('更新', 'Updated'),
     key: 'updated_at',
     width: 140,
     render: (row) => (row.price ? formatDateTime(row.price.updated_at) : '-'),
@@ -665,25 +697,25 @@ const columns: DataTableColumns<PriceDisplayRow> = [
               ? h(
                   NButton,
                   { size: 'small', quaternary: true, onClick: () => openEdit(row.price as ModelPrice) },
-                  { default: () => '改价' },
+                  { default: () => t('改价', 'Edit') },
                 )
               : h(
                   NButton,
                   { size: 'small', type: 'primary', secondary: true, onClick: () => openCreateForRow(row) },
-                  { default: () => '设价' },
+                  { default: () => t('设价', 'Set price') },
                 ),
             row.price
               ? h(
                   NButton,
                   { size: 'small', quaternary: true, type: 'error', onClick: () => confirmDelete(row.price as ModelPrice) },
-                  { default: () => '删除' },
+                  { default: () => t('删除', 'Delete') },
                 )
               : null,
           ],
         },
       ),
   },
-]
+])
 
 onMounted(() => {
   desktopPriceLayoutQuery.addEventListener('change', handleDesktopPriceLayoutChange)
@@ -699,23 +731,25 @@ onBeforeUnmount(() => {
   <section class="page price-page">
     <div class="page-header">
       <div>
-        <h1 class="page-title">模型价格</h1>
-        <p class="page-subtitle">Token 模型按 USD / 百万 Token 计费，image 模型按每次成功调用计费</p>
+        <h1 class="page-title">{{ t('模型价格', 'Model prices') }}</h1>
+        <p class="page-subtitle">
+          {{ t('Token 模型按 USD / 百万 Token 计费，image 模型按每次成功调用计费', 'Token models are charged in USD per million tokens. Image models are charged per successful call.') }}
+        </p>
       </div>
       <NSpace>
         <NButton secondary :loading="isSyncing" @click="syncPrices">
           <template #icon>
             <NIcon :component="RefreshCw" />
           </template>
-          同步 LiteLLM
+          {{ t('同步 LiteLLM', 'Sync LiteLLM') }}
         </NButton>
         <NButton secondary :disabled="isSyncing" @click="openProxySettings">
           <template #icon>
             <NIcon :component="Settings2" />
           </template>
-          代理配置
+          {{ t('代理配置', 'Proxy settings') }}
         </NButton>
-        <NButton type="primary" @click="() => openCreate()">新增价格</NButton>
+        <NButton type="primary" @click="() => openCreate()">{{ t('新增价格', 'Add price') }}</NButton>
       </NSpace>
     </div>
 
@@ -738,31 +772,33 @@ onBeforeUnmount(() => {
         <div class="table-toolbar">
           <NSpace class="price-toolbar-layout" justify="space-between" align="center">
             <NSpace class="price-filters" align="center" :size="8">
-              <span class="filter-label">服务商</span>
+              <span class="filter-label">{{ t('服务商', 'Provider') }}</span>
               <NSelect
                 v-model:value="selectedProvider"
                 class="provider-filter"
                 :options="providerOptions"
                 clearable
                 filterable
-                placeholder="全部服务商"
+                :placeholder="t('全部服务商', 'All providers')"
               />
               <NSelect
                 v-model:value="selectedStatus"
                 class="status-filter"
                 :options="statusOptions"
                 clearable
-                placeholder="全部状态"
+                :placeholder="t('全部状态', 'All statuses')"
               />
               <NInput
                 v-model:value="searchQuery"
                 class="price-search"
                 clearable
-                placeholder="搜索模型或服务商"
+                :placeholder="t('搜索模型或服务商', 'Search models or providers')"
                 :render-prefix="renderSearchIcon"
               />
             </NSpace>
-            <span class="result-count">共 {{ filteredPriceCount }} / {{ totalPriceCount }} 条</span>
+            <span class="result-count">
+              {{ t(`共 ${filteredPriceCount} / ${totalPriceCount} 条`, `${filteredPriceCount} / ${totalPriceCount} items`) }}
+            </span>
           </NSpace>
         </div>
       </div>
@@ -782,32 +818,32 @@ onBeforeUnmount(() => {
     <NModal
       v-model:show="modalOpen"
       preset="card"
-      :title="editingId === null ? '新增价格' : '编辑价格'"
+      :title="editingId === null ? t('新增价格', 'Add price') : t('编辑价格', 'Edit price')"
       :style="priceModalStyle"
       class="price-modal"
     >
       <NForm :model="form" label-placement="top">
         <div class="form-grid">
-          <NFormItem label="服务商">
+          <NFormItem :label="t('服务商', 'Provider')">
             <NInput v-model:value="form.provider" />
           </NFormItem>
-          <NFormItem label="模型">
+          <NFormItem :label="t('模型', 'Model')">
             <NInput v-model:value="form.model" />
           </NFormItem>
-          <NFormItem v-if="isRequestPriceForm" label="每次调用价格 USD" class="wide-form-item">
-            <NInputNumber v-model:value="form.request_usd" :min="0" placeholder="例如：0.04" />
+          <NFormItem v-if="isRequestPriceForm" :label="t('每次调用价格 USD', 'Per-call price USD')" class="wide-form-item">
+            <NInputNumber v-model:value="form.request_usd" :min="0" :placeholder="t('例如：0.04', 'Example: 0.04')" />
           </NFormItem>
           <template v-else>
-            <NFormItem label="输入价格">
+            <NFormItem :label="t('输入价格', 'Input price')">
               <NInputNumber v-model:value="form.input_usd_per_million" :min="0" />
             </NFormItem>
-            <NFormItem label="输出价格">
+            <NFormItem :label="t('输出价格', 'Output price')">
               <NInputNumber v-model:value="form.output_usd_per_million" :min="0" />
             </NFormItem>
-            <NFormItem label="缓存读价格">
+            <NFormItem :label="t('缓存读价格', 'Cache read price')">
               <NInputNumber v-model:value="form.cache_read_usd_per_million" :min="0" />
             </NFormItem>
-            <NFormItem label="缓存写价格">
+            <NFormItem :label="t('缓存写价格', 'Cache write price')">
               <NInputNumber v-model:value="form.cache_creation_usd_per_million" :min="0" />
             </NFormItem>
           </template>
@@ -816,8 +852,8 @@ onBeforeUnmount(() => {
       <p class="price-save-hint">{{ priceSaveHint }}</p>
       <template #footer>
         <NSpace justify="end">
-          <NButton @click="modalOpen = false">取消</NButton>
-          <NButton type="primary" @click="savePrice">保存</NButton>
+          <NButton @click="modalOpen = false">{{ t('取消', 'Cancel') }}</NButton>
+          <NButton type="primary" @click="savePrice">{{ t('保存', 'Save') }}</NButton>
         </NSpace>
       </template>
     </NModal>
@@ -825,7 +861,7 @@ onBeforeUnmount(() => {
     <NModal
       v-model:show="proxyModalOpen"
       preset="card"
-      title="LiteLLM 代理配置"
+      :title="t('LiteLLM 代理配置', 'LiteLLM proxy settings')"
       :style="proxyModalStyle"
       :content-style="proxyModalContentStyle"
       :footer-style="proxyModalFooterStyle"
@@ -835,26 +871,26 @@ onBeforeUnmount(() => {
         <div class="proxy-form">
           <p class="proxy-hint">{{ liteLLMProxyHint }}</p>
           <div class="proxy-switch-row">
-            <span class="proxy-switch-label">使用代理</span>
+            <span class="proxy-switch-label">{{ t('使用代理', 'Use proxy') }}</span>
             <NSwitch
               v-model:value="proxyForm.enabled"
               :disabled="isProxyLoading || isProxySaving"
-              aria-label="使用代理"
+              :aria-label="t('使用代理', 'Use proxy')"
             />
           </div>
-          <NFormItem label="代理地址">
+          <NFormItem :label="t('代理地址', 'Proxy URL')">
             <NInput
               v-model:value="proxyForm.proxy_url"
               :disabled="!proxyForm.enabled || isProxyLoading || isProxySaving"
-              placeholder="http://127.0.0.1:7890 或 socks5://127.0.0.1:1080"
+              :placeholder="t('http://127.0.0.1:7890 或 socks5://127.0.0.1:1080', 'http://127.0.0.1:7890 or socks5://127.0.0.1:1080')"
             />
           </NFormItem>
         </div>
       </NForm>
       <template #footer>
         <NSpace justify="end">
-          <NButton :disabled="isProxySaving" @click="proxyModalOpen = false">取消</NButton>
-          <NButton type="primary" :loading="isProxySaving" @click="saveProxySettings">保存</NButton>
+          <NButton :disabled="isProxySaving" @click="proxyModalOpen = false">{{ t('取消', 'Cancel') }}</NButton>
+          <NButton type="primary" :loading="isProxySaving" @click="saveProxySettings">{{ t('保存', 'Save') }}</NButton>
         </NSpace>
       </template>
     </NModal>

--- a/frontend/src/features/settings/views/AccountSettingsView.vue
+++ b/frontend/src/features/settings/views/AccountSettingsView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { NButton, NForm, NFormItem, NInput, NSpace, useMessage } from 'naive-ui'
 import { ShieldCheck, UserRound } from 'lucide-vue-next'
 
 import { changeCredentials, getMe } from '@/features/auth/api/authApi'
 import { setCurrentUser } from '@/features/auth/state/currentUser'
+import { useI18n } from '@/shared/i18n'
 
 const message = useMessage()
+const { errorText, t } = useI18n()
 const isLoading = ref(false)
 const isSaving = ref(false)
 const isAdmin = ref(false)
@@ -16,6 +18,7 @@ const accountForm = reactive({
   password: '',
   current_password: '',
 })
+const roleText = computed(() => (isAdmin.value ? t('管理员', 'Admin') : t('普通账户', 'Standard account')))
 
 async function refresh() {
   isLoading.value = true
@@ -25,7 +28,7 @@ async function refresh() {
     accountForm.username = user.username
     isAdmin.value = user.is_admin
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载账户失败')
+    message.error(errorText(error, '加载账户失败', 'Failed to load account'))
   } finally {
     isLoading.value = false
   }
@@ -43,9 +46,9 @@ async function saveAccount() {
     accountForm.username = user.username
     accountForm.password = ''
     accountForm.current_password = ''
-    message.success('账户已更新')
+    message.success(t('账户已更新', 'Account updated'))
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '账户更新失败')
+    message.error(errorText(error, '账户更新失败', 'Failed to update account'))
   } finally {
     isSaving.value = false
   }
@@ -58,12 +61,12 @@ onMounted(refresh)
   <section class="page">
     <div class="page-header">
       <div>
-        <h1 class="page-title">账户设置</h1>
-        <p class="page-subtitle">查看账号并更新当前登录密码</p>
+        <h1 class="page-title">{{ t('账户设置', 'Account Settings') }}</h1>
+        <p class="page-subtitle">{{ t('查看账号并更新当前登录密码', 'View your account and update the current sign-in password') }}</p>
       </div>
       <NSpace>
-        <NButton secondary :loading="isLoading" @click="refresh">刷新</NButton>
-        <NButton type="primary" :loading="isSaving" @click="saveAccount">保存账户</NButton>
+        <NButton secondary :loading="isLoading" @click="refresh">{{ t('刷新', 'Refresh') }}</NButton>
+        <NButton type="primary" :loading="isSaving" @click="saveAccount">{{ t('保存账户', 'Save account') }}</NButton>
       </NSpace>
     </div>
 
@@ -72,29 +75,29 @@ onMounted(refresh)
         <div class="metric-icon" aria-hidden="true">
           <UserRound :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">当前账号</div>
+        <div class="metric-label">{{ t('当前账号', 'Current account') }}</div>
         <div class="metric-value">{{ accountForm.username || '-' }}</div>
-        <div class="metric-footnote">登录身份</div>
+        <div class="metric-footnote">{{ t('登录身份', 'Sign-in identity') }}</div>
       </div>
       <div class="metric-card is-purple">
         <div class="metric-icon" aria-hidden="true">
           <ShieldCheck :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">权限</div>
-        <div class="metric-value">{{ isAdmin ? '管理员' : '普通账户' }}</div>
-        <div class="metric-footnote">当前会话</div>
+        <div class="metric-label">{{ t('权限', 'Role') }}</div>
+        <div class="metric-value">{{ roleText }}</div>
+        <div class="metric-footnote">{{ t('当前会话', 'Current session') }}</div>
       </div>
     </div>
 
     <section class="panel">
       <div class="panel-inner">
-        <h2 class="section-title">账号与密码</h2>
+        <h2 class="section-title">{{ t('账号与密码', 'Account and Password') }}</h2>
         <NForm :model="accountForm" label-placement="top">
           <div class="form-grid">
-            <NFormItem label="账号">
+            <NFormItem :label="t('账号', 'Account')">
               <NInput v-model:value="accountForm.username" autocomplete="username" disabled />
             </NFormItem>
-            <NFormItem label="当前密码">
+            <NFormItem :label="t('当前密码', 'Current password')">
               <NInput
                 v-model:value="accountForm.current_password"
                 type="password"
@@ -102,7 +105,7 @@ onMounted(refresh)
                 autocomplete="current-password"
               />
             </NFormItem>
-            <NFormItem label="新密码">
+            <NFormItem :label="t('新密码', 'New password')">
               <NInput
                 v-model:value="accountForm.password"
                 type="password"

--- a/frontend/src/features/settings/views/SettingsView.vue
+++ b/frontend/src/features/settings/views/SettingsView.vue
@@ -21,10 +21,12 @@ import {
   getSettings,
   updateSettings,
 } from '@/features/settings/api/settingsApi'
+import { useI18n } from '@/shared/i18n'
 import type { CollectorStatus, SettingsUpdatePayload } from '@/shared/types/api'
 import { formatDateTime, formatInteger } from '@/shared/utils/format'
 
 const message = useMessage()
+const { errorText, serverText, t } = useI18n()
 const isLoading = ref(false)
 const isSaving = ref(false)
 const collectorStatus = ref<CollectorStatus | null>(null)
@@ -51,16 +53,16 @@ const remoteStatusType = computed(() => {
 
 const remoteStatusText = computed(() => {
   if (collectorStatus.value?.remote_enabled === true) {
-    return '开启'
+    return t('开启', 'On')
   }
   if (collectorStatus.value?.remote_enabled === false) {
-    return '关闭'
+    return t('关闭', 'Off')
   }
-  return '未知'
+  return t('未知', 'Unknown')
 })
 
-const collectorEnabledText = computed(() => (collectorStatus.value?.enabled ? '开启' : '关闭'))
-const collectorRunningText = computed(() => (collectorStatus.value?.running ? '运行中' : '空闲'))
+const collectorEnabledText = computed(() => (collectorStatus.value?.enabled ? t('开启', 'On') : t('关闭', 'Off')))
+const collectorRunningText = computed(() => (collectorStatus.value?.running ? t('运行中', 'Running') : t('空闲', 'Idle')))
 
 async function refresh() {
   isLoading.value = true
@@ -78,7 +80,7 @@ async function refresh() {
     settingsForm.retry_interval_seconds = settings.retry_interval_seconds
     collectorStatus.value = status
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载设置失败')
+    message.error(errorText(error, '加载设置失败', 'Failed to load settings'))
   } finally {
     isLoading.value = false
   }
@@ -98,10 +100,10 @@ async function saveSettings() {
     }
     const saved = await updateSettings(payload)
     settingsForm.management_key = saved.management_key
-    message.success('设置已保存')
+    message.success(t('设置已保存', 'Settings saved'))
     await refresh()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '保存设置失败')
+    message.error(errorText(error, '保存设置失败', 'Failed to save settings'))
   } finally {
     isSaving.value = false
   }
@@ -114,12 +116,12 @@ onMounted(refresh)
   <section class="page">
     <div class="page-header">
       <div>
-        <h1 class="page-title">系统设置</h1>
-        <p class="page-subtitle">集中管理采集配置</p>
+        <h1 class="page-title">{{ t('系统设置', 'System Settings') }}</h1>
+        <p class="page-subtitle">{{ t('集中管理采集配置', 'Manage collection settings in one place') }}</p>
       </div>
       <NSpace>
-        <NButton secondary :loading="isLoading" @click="refresh">刷新</NButton>
-        <NButton type="primary" :loading="isSaving" @click="saveSettings">保存设置</NButton>
+        <NButton secondary :loading="isLoading" @click="refresh">{{ t('刷新', 'Refresh') }}</NButton>
+        <NButton type="primary" :loading="isSaving" @click="saveSettings">{{ t('保存设置', 'Save settings') }}</NButton>
       </NSpace>
     </div>
 
@@ -128,23 +130,23 @@ onMounted(refresh)
         <div class="metric-icon" aria-hidden="true">
           <Power :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">本地采集</div>
+        <div class="metric-label">{{ t('本地采集', 'Local collection') }}</div>
         <div class="metric-value">{{ collectorEnabledText }}</div>
-        <div class="metric-footnote">系统开关</div>
+        <div class="metric-footnote">{{ t('系统开关', 'System switch') }}</div>
       </div>
       <div class="metric-card" :class="collectorStatus?.running ? 'is-teal' : 'is-blue'">
         <div class="metric-icon" aria-hidden="true">
           <Activity :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">运行状态</div>
+        <div class="metric-label">{{ t('运行状态', 'Run status') }}</div>
         <div class="metric-value">{{ collectorRunningText }}</div>
-        <div class="metric-footnote">采集进程</div>
+        <div class="metric-footnote">{{ t('采集进程', 'Collector process') }}</div>
       </div>
       <div class="metric-card" :class="remoteStatusType === 'success' ? 'is-green' : 'is-purple'">
         <div class="metric-icon" aria-hidden="true">
           <Server :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">远端开关</div>
+        <div class="metric-label">{{ t('远端开关', 'Remote switch') }}</div>
         <div class="metric-value">{{ remoteStatusText }}</div>
         <div class="metric-footnote">CLIProxyAPI</div>
       </div>
@@ -152,49 +154,49 @@ onMounted(refresh)
         <div class="metric-icon" aria-hidden="true">
           <Database :size="20" :stroke-width="2.2" />
         </div>
-        <div class="metric-label">累计写入</div>
+        <div class="metric-label">{{ t('累计写入', 'Records written') }}</div>
         <div class="metric-value">{{ formatInteger(collectorStatus?.records_collected ?? 0) }}</div>
-        <div class="metric-footnote">本地记录</div>
+        <div class="metric-footnote">{{ t('本地记录', 'Local records') }}</div>
       </div>
     </div>
 
     <div class="grid-two">
       <section class="panel">
         <div class="panel-inner">
-          <h2 class="section-title">采集配置</h2>
+          <h2 class="section-title">{{ t('采集配置', 'Collection Settings') }}</h2>
           <NForm :model="settingsForm" label-placement="top">
             <div class="form-grid">
               <div class="field-stack">
-                <div class="field-label">CLIProxyAPI 地址</div>
+                <div class="field-label">{{ t('CLIProxyAPI 地址', 'CLIProxyAPI URL') }}</div>
                 <NInput v-model:value="settingsForm.cliaproxy_url" />
-                <div class="form-help">用于采集队列、API Key 同步和管理接口。</div>
+                <div class="form-help">{{ t('用于采集队列、API Key 同步和管理接口。', 'Used for collection queues, API key sync, and management APIs.') }}</div>
               </div>
               <div class="field-stack">
-                <div class="field-label">模型请求地址（例如：填写CPA外网地址）</div>
+                <div class="field-label">{{ t('模型请求地址（例如：填写CPA外网地址）', 'Model request URL (for example, CPA public URL)') }}</div>
                 <NInput
                   v-model:value="settingsForm.model_request_url"
-                  placeholder="例如：http://192.168.26.50:8317"
+                  :placeholder="t('例如：http://192.168.26.50:8317', 'Example: http://192.168.26.50:8317')"
                 />
-                <div class="form-help">仅用于 API 密钥页「请求测试」生成 URL 和示例。</div>
+                <div class="form-help">{{ t('仅用于 API 密钥页「请求测试」生成 URL 和示例。', 'Only used to generate URLs and examples for request tests on the API keys page.') }}</div>
               </div>
-              <NFormItem label="管理密钥">
+              <NFormItem :label="t('管理密钥', 'Management key')">
                 <NInput
                   v-model:value="settingsForm.management_key"
                   type="password"
                   show-password-on="mousedown"
-                  placeholder="请输入 CLIProxyAPI 管理密钥"
+                  :placeholder="t('请输入 CLIProxyAPI 管理密钥', 'Enter the CLIProxyAPI management key')"
                 />
               </NFormItem>
-              <NFormItem label="开启本地采集">
+              <NFormItem :label="t('开启本地采集', 'Enable local collection')">
                 <NSwitch v-model:value="settingsForm.collector_enabled" />
               </NFormItem>
-              <NFormItem label="批量读取数">
+              <NFormItem :label="t('批量读取数', 'Batch size')">
                 <NInputNumber v-model:value="settingsForm.batch_size" :min="1" :max="1000" />
               </NFormItem>
-              <NFormItem label="轮询间隔（秒）">
+              <NFormItem :label="t('轮询间隔（秒）', 'Poll interval (seconds)')">
                 <NInputNumber v-model:value="settingsForm.poll_interval_seconds" :min="0.2" />
               </NFormItem>
-              <NFormItem label="重试间隔（秒）">
+              <NFormItem :label="t('重试间隔（秒）', 'Retry interval (seconds)')">
                 <NInputNumber v-model:value="settingsForm.retry_interval_seconds" :min="1" />
               </NFormItem>
             </div>
@@ -204,30 +206,30 @@ onMounted(refresh)
 
       <section class="panel">
         <div class="panel-inner">
-          <h2 class="section-title">采集状态</h2>
+          <h2 class="section-title">{{ t('采集状态', 'Collection Status') }}</h2>
           <NDescriptions label-placement="left" :column="1" size="small" bordered>
-            <NDescriptionsItem label="本地采集">
+            <NDescriptionsItem :label="t('本地采集', 'Local collection')">
               <NTag :type="collectorStatus?.enabled ? 'success' : 'default'" size="small">
-                {{ collectorStatus?.enabled ? '开启' : '关闭' }}
+                {{ collectorStatus?.enabled ? t('开启', 'On') : t('关闭', 'Off') }}
               </NTag>
             </NDescriptionsItem>
-            <NDescriptionsItem label="运行状态">
+            <NDescriptionsItem :label="t('运行状态', 'Run status')">
               <NTag :type="collectorStatus?.running ? 'success' : 'default'" size="small">
-                {{ collectorStatus?.running ? '运行中' : '空闲' }}
+                {{ collectorStatus?.running ? t('运行中', 'Running') : t('空闲', 'Idle') }}
               </NTag>
             </NDescriptionsItem>
-            <NDescriptionsItem label="远端开关">
+            <NDescriptionsItem :label="t('远端开关', 'Remote switch')">
               <NTag :type="remoteStatusType" size="small">
                 {{ remoteStatusText }}
               </NTag>
             </NDescriptionsItem>
-            <NDescriptionsItem label="累计写入">
+            <NDescriptionsItem :label="t('累计写入', 'Records written')">
               {{ formatInteger(collectorStatus?.records_collected ?? 0) }}
             </NDescriptionsItem>
-            <NDescriptionsItem label="最后轮询">
+            <NDescriptionsItem :label="t('最后轮询', 'Last poll')">
               {{ formatDateTime(collectorStatus?.last_poll_at ?? null) }}
             </NDescriptionsItem>
-            <NDescriptionsItem label="最后成功">
+            <NDescriptionsItem :label="t('最后成功', 'Last success')">
               {{ formatDateTime(collectorStatus?.last_success_at ?? null) }}
             </NDescriptionsItem>
           </NDescriptions>
@@ -237,7 +239,7 @@ onMounted(refresh)
             :bordered="false"
             class="status-alert"
           >
-            {{ collectorStatus.last_error }}
+            {{ serverText(collectorStatus.last_error, '采集异常', 'Collector error') }}
           </NAlert>
         </div>
       </section>

--- a/frontend/src/features/usage/components/ChartPanel.vue
+++ b/frontend/src/features/usage/components/ChartPanel.vue
@@ -19,6 +19,7 @@ import type { BarSeriesOption, LineSeriesOption, PieSeriesOption } from 'echarts
 import type { ComposeOption, ECharts } from 'echarts/core'
 
 import { useThemePreference } from '@/shared/composables/useThemePreference'
+import { useI18n } from '@/shared/i18n'
 
 echarts.use([
   BarChart,
@@ -53,6 +54,7 @@ const props = defineProps<{
 const chartEl = ref<HTMLDivElement | null>(null)
 const chart = ref<ECharts | null>(null)
 const { isDark } = useThemePreference()
+const { t } = useI18n()
 
 let chartThemeFrame: number | undefined
 
@@ -153,7 +155,7 @@ onBeforeUnmount(() => {
       <div class="chart-body">
         <div ref="chartEl" class="chart-surface" :class="{ 'is-empty': empty }" />
         <div v-if="empty" class="chart-empty">
-          <NEmpty description="暂无数据" />
+          <NEmpty :description="t('暂无数据', 'No data')" />
         </div>
       </div>
       <div v-if="$slots.default" class="chart-footer">

--- a/frontend/src/features/usage/views/UsageHistoryView.vue
+++ b/frontend/src/features/usage/views/UsageHistoryView.vue
@@ -34,6 +34,7 @@ import {
   formatLocalDateTimeParam,
   formatUsd,
 } from '@/shared/utils/format'
+import { useI18n } from '@/shared/i18n'
 
 type FailedFilter = 'all' | 'success' | 'failed'
 type QuickRangeKey = 'today' | 'last24h' | 'last3d' | 'last7d' | 'last30d'
@@ -88,14 +89,6 @@ const AUTO_REFRESH_INTERVAL_MS = 5000
 const HOUR_MS = 60 * 60 * 1000
 const DAY_MS = 24 * HOUR_MS
 const THIRTY_MINUTES_MS = 30 * 60 * 1000
-const quickRangeOptions: Array<{ key: QuickRangeKey; label: string }> = [
-  { key: 'today', label: '今日' },
-  { key: 'last24h', label: '近 24 小时' },
-  { key: 'last3d', label: '近 3 日' },
-  { key: 'last7d', label: '近 7 日' },
-  { key: 'last30d', label: '近 30 日' },
-]
-
 const DISTRIBUTION_CHART_COLORS = [
   { token: '--cpa-chart-1', fallback: '#009aa8' },
   { token: '--cpa-chart-2', fallback: '#1d8dff' },
@@ -108,6 +101,7 @@ const route = useRoute()
 const router = useRouter()
 const message = useMessage()
 const props = defineProps<Props>()
+const { currentLanguage, errorText, t } = useI18n()
 const isLoading = ref(false)
 const isAutoRefreshing = ref(false)
 const autoRefreshError = ref<string | null>(null)
@@ -213,7 +207,7 @@ function buildQuickRange(key: QuickRangeKey): [number, number] {
 }
 
 function isQuickRangeKey(value: unknown): value is QuickRangeKey {
-  return typeof value === 'string' && quickRangeOptions.some((option) => option.key === value)
+  return typeof value === 'string' && quickRangeOptions.value.some((option) => option.key === value)
 }
 
 function quickRangeFromQuery(): QuickRangeKey | null {
@@ -268,6 +262,14 @@ function numberFromQuery(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+const quickRangeOptions = computed<Array<{ key: QuickRangeKey; label: string }>>(() => [
+  { key: 'today', label: t('今日', 'Today') },
+  { key: 'last24h', label: t('近 24 小时', 'Last 24 hours') },
+  { key: 'last3d', label: t('近 3 日', 'Last 3 days') },
+  { key: 'last7d', label: t('近 7 日', 'Last 7 days') },
+  { key: 'last30d', label: t('近 30 日', 'Last 30 days') },
+])
+
 const initialQuickRange = quickRangeFromQuery()
 const initialDateRange = initialRange()
 const inferredQuickRange = initialQuickRange ?? inferQuickRangeFromRange(initialDateRange)
@@ -287,6 +289,12 @@ const filterForm = reactive({
   failed: failedFromQuery(),
 })
 
+const failedFilterOptions = computed(() => [
+  { label: t('全部', 'All'), value: 'all' },
+  { label: t('成功', 'Success'), value: 'success' },
+  { label: t('失败', 'Failed'), value: 'failed' },
+])
+
 function apiKeyFilterLabel(item: UsageOptionsResponse['api_key_descriptions'][number]): string {
   return item.label?.trim() || item.key
 }
@@ -305,35 +313,44 @@ const selectOptions = computed(() => ({
 }))
 
 const isAccountScope = computed(() => props.scope === 'account')
-const pageTitle = computed(() => (isAccountScope.value ? '我的用量' : '历史用量'))
+const pageTitle = computed(() =>
+  isAccountScope.value ? t('我的用量', 'My usage') : t('历史用量', 'Usage history'),
+)
 const pageSubtitle = computed(() =>
   isAccountScope.value
-    ? '仅聚合当前登录账号自己的本地用量记录'
-    : '按本地 SQLite 历史记录实时聚合，费用按当前模型价格估算',
+    ? t('仅聚合当前登录账号自己的本地用量记录', 'Only local usage records for your account are aggregated')
+    : t(
+        '按本地 SQLite 历史记录实时聚合，费用按当前模型价格估算',
+        'Aggregated live from local SQLite history. Costs are estimated using current model prices.',
+      ),
 )
-const rankingTitle = computed(() => (isAccountScope.value ? 'KEY 排行' : '用户排行'))
+const rankingTitle = computed(() =>
+  isAccountScope.value ? t('KEY 排行', 'Key ranking') : t('用户排行', 'User ranking'),
+)
 
 const refreshStatusText = computed(() => {
   const lastRefreshTime = lastRefreshedAt.value
   if (!lastRefreshTime) {
-    return autoRefreshError.value ? '自动刷新异常 · 尚无成功同步' : '每 5 秒自动刷新 · 等待首次同步'
+    return autoRefreshError.value
+      ? t('自动刷新异常 · 尚无成功同步', 'Auto refresh error · no successful sync yet')
+      : t('每 5 秒自动刷新 · 等待首次同步', 'Auto refresh every 5 seconds · waiting for first sync')
   }
-  const lastRefreshText = new Intl.DateTimeFormat('zh-CN', {
+  const lastRefreshText = new Intl.DateTimeFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
   }).format(lastRefreshTime)
   if (autoRefreshError.value) {
-    return `自动刷新异常 · 最近成功 ${lastRefreshText}`
+    return t(`自动刷新异常 · 最近成功 ${lastRefreshText}`, `Auto refresh error · last success ${lastRefreshText}`)
   }
   if (auxiliaryError.value) {
-    return `已同步 ${lastRefreshText} · 辅助指标降级`
+    return t(`已同步 ${lastRefreshText} · 辅助指标降级`, `Synced ${lastRefreshText} · auxiliary metrics degraded`)
   }
-  return `每 5 秒自动刷新 · 最近 ${lastRefreshText}`
+  return t(`每 5 秒自动刷新 · 最近 ${lastRefreshText}`, `Auto refresh every 5 seconds · latest ${lastRefreshText}`)
 })
 
 const dashboardRangeLabel = computed(() => {
-  const activeRange = quickRangeOptions.find((option) => option.key === activeQuickRange.value)
+  const activeRange = quickRangeOptions.value.find((option) => option.key === activeQuickRange.value)
   if (activeRange) {
     return activeRange.label
   }
@@ -346,17 +363,17 @@ const dashboardRangeLabel = computed(() => {
   }
   const range = dateRange.value
   if (!range) {
-    return '当前筛选'
+    return t('当前筛选', 'Current filters')
   }
   return `${formatMetricRangeTime(range[0])} - ${formatMetricRangeTime(range[1])}`
 })
 
 const rateRangeLabel = computed(() =>
-  activeQuickRange.value === 'today' ? '近 30 分钟' : dashboardRangeLabel.value,
+  activeQuickRange.value === 'today' ? t('近 30 分钟', 'Last 30 minutes') : dashboardRangeLabel.value,
 )
 
 function formatMetricRangeTime(value: number): string {
-  return new Intl.DateTimeFormat('zh-CN', {
+  return new Intl.DateTimeFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     timeZone: BEIJING_TIME_ZONE,
     month: '2-digit',
     day: '2-digit',
@@ -567,7 +584,7 @@ async function refresh({ silent = false }: RefreshOptions = {}) {
       failedResult.status === 'rejected' ||
       realtimeResult.status === 'rejected' ||
       quotaResult.status === 'rejected'
-        ? '部分辅助指标加载失败'
+        ? t('部分辅助指标加载失败', 'Some auxiliary metrics failed to load')
         : null
 
     void router.replace({
@@ -581,7 +598,7 @@ async function refresh({ silent = false }: RefreshOptions = {}) {
     autoRefreshError.value = null
     lastRefreshedAt.value = new Date()
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : '加载历史用量失败'
+    const errorMessage = errorText(error, '加载历史用量失败', 'Failed to load usage history')
     if (silent) {
       autoRefreshError.value = errorMessage
     } else {
@@ -661,7 +678,7 @@ function distributionLegendItems(items: DistributionItem[]): DistributionLegendI
 }
 
 function formatPercent(value: number): string {
-  return new Intl.NumberFormat('zh-CN', {
+  return new Intl.NumberFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     style: 'percent',
     maximumFractionDigits: value > 0 && value < 0.1 ? 1 : 0,
   }).format(value)
@@ -730,31 +747,37 @@ const requestsPerMinute = computed(() => {
 
 function quotaValueText(quota: UserQuotaStatus | null): string {
   if (!quota) {
-    return '加载中'
+    return t('加载中', 'Loading')
   }
   if (quota.unlimited) {
-    return '每月余额 无限制'
+    return t('每月余额 无限制', 'Monthly balance unlimited')
   }
-  return `每月余额 ${formatUsd(quota.monthly_remaining_usd ?? 0)}`
+  return t(
+    `每月余额 ${formatUsd(quota.monthly_remaining_usd ?? 0)}`,
+    `Monthly balance ${formatUsd(quota.monthly_remaining_usd ?? 0)}`,
+  )
 }
 
 function quotaFootnote(quota: UserQuotaStatus | null): string {
   if (!quota) {
-    return '额度加载中'
+    return t('额度加载中', 'Quota loading')
   }
   if (quota.unlimited) {
-    return '不限时余额 无限制'
+    return t('不限时余额 无限制', 'Lifetime balance unlimited')
   }
-  const lifetimeText = `不限时余额 ${formatUsd(quota.lifetime_remaining_usd ?? 0)}`
+  const lifetimeText = t(
+    `不限时余额 ${formatUsd(quota.lifetime_remaining_usd ?? 0)}`,
+    `Lifetime balance ${formatUsd(quota.lifetime_remaining_usd ?? 0)}`,
+  )
   const notes: string[] = []
   if (quota.sync_error) {
-    notes.push('Key 同步异常')
+    notes.push(t('Key 同步异常', 'Key sync error'))
   }
   if (quota.unpriced_records > 0) {
-    notes.push(`未定价 ${formatInteger(quota.unpriced_records)} 条`)
+    notes.push(t(`未定价 ${formatInteger(quota.unpriced_records)} 条`, `${formatInteger(quota.unpriced_records)} unpriced records`))
   }
   if (quota.paused) {
-    notes.push('Key 已因余额暂停')
+    notes.push(t('Key 已因余额暂停', 'Key paused due to balance'))
   }
   return notes.length > 0 ? `${lifetimeText} · ${notes.join(' · ')}` : lifetimeText
 }
@@ -764,7 +787,7 @@ const metricCards = computed<MetricCardConfig[]>(() => {
   return [
     {
       key: 'requests',
-      label: '请求数',
+      label: t('请求数', 'Requests'),
       value: formatInteger(currentSummary?.total_records ?? 0),
       icon: ClipboardList,
       tone: 'blue',
@@ -772,23 +795,33 @@ const metricCards = computed<MetricCardConfig[]>(() => {
     },
     {
       key: 'success',
-      label: '成功率',
+      label: t('成功率', 'Success rate'),
       value: formatPercent(successRate.value),
       icon: ShieldCheck,
       tone: 'green',
-      footnote: `${formatInteger(currentSummary?.success_records ?? 0)} 成功 / ${formatInteger(
-        currentSummary?.total_records ?? 0,
-      )} 请求`,
+      footnote: t(
+        `${formatInteger(currentSummary?.success_records ?? 0)} 成功 / ${formatInteger(
+          currentSummary?.total_records ?? 0,
+        )} 请求`,
+        `${formatInteger(currentSummary?.success_records ?? 0)} succeeded / ${formatInteger(
+          currentSummary?.total_records ?? 0,
+        )} requests`,
+      ),
     },
     {
       key: 'total_tokens',
-      label: '总 Token',
+      label: t('总 Token', 'Total tokens'),
       value: formatCompact(currentSummary?.total_tokens ?? 0),
       icon: Layers3,
       tone: 'purple',
-      footnote: `输入 ${formatCompact(currentSummary?.input_tokens ?? 0)} / 输出 ${formatCompact(
-        currentSummary?.output_tokens ?? 0,
-      )}`,
+      footnote: t(
+        `输入 ${formatCompact(currentSummary?.input_tokens ?? 0)} / 输出 ${formatCompact(
+          currentSummary?.output_tokens ?? 0,
+        )}`,
+        `Input ${formatCompact(currentSummary?.input_tokens ?? 0)} / output ${formatCompact(
+          currentSummary?.output_tokens ?? 0,
+        )}`,
+      ),
     },
     {
       key: 'rpm',
@@ -800,7 +833,7 @@ const metricCards = computed<MetricCardConfig[]>(() => {
     },
     {
       key: 'average_ttft',
-      label: '平均首字耗时',
+      label: t('平均首字耗时', 'Avg TTFT'),
       value: formatLatency(currentSummary?.average_ttft_ms ?? null),
       icon: Timer,
       tone: 'teal',
@@ -808,14 +841,17 @@ const metricCards = computed<MetricCardConfig[]>(() => {
     },
     {
       key: 'cost',
-      label: '估算费用',
+      label: t('估算费用', 'Estimated cost'),
       value: formatUsd(currentSummary?.estimated_cost_usd ?? 0),
       icon: CircleDollarSign,
       tone: 'green',
       footnote:
         (currentSummary?.unpriced_records ?? 0) > 0
-          ? `未计价 ${formatInteger(currentSummary?.unpriced_records ?? 0)} 条`
-          : '按当前价格估算',
+          ? t(
+              `未计价 ${formatInteger(currentSummary?.unpriced_records ?? 0)} 条`,
+              `${formatInteger(currentSummary?.unpriced_records ?? 0)} unpriced records`,
+            )
+          : t('按当前价格估算', 'Estimated at current prices'),
     },
   ]
 })
@@ -841,7 +877,7 @@ const trendOption = computed<ChartOption>(() => {
       itemGap: 14,
       itemWidth: 10,
       itemHeight: 10,
-      data: ['请求数', 'Token', '失败请求'],
+      data: [t('请求数', 'Requests'), 'Token', t('失败请求', 'Failed requests')],
     },
     grid: { left: 42, right: 58, top: 44, bottom: 34 },
     xAxis: {
@@ -858,7 +894,7 @@ const trendOption = computed<ChartOption>(() => {
     yAxis: [
       {
         type: 'value',
-        name: '请求',
+        name: t('请求', 'Requests'),
         nameTextStyle: { color: mutedColor },
         axisLabel: { color: mutedColor, formatter: (value: number) => formatCompact(value) },
         splitLine: { lineStyle: { color: gridColor } },
@@ -873,7 +909,7 @@ const trendOption = computed<ChartOption>(() => {
     ],
     series: [
       {
-        name: '请求数',
+        name: t('请求数', 'Requests'),
         type: 'bar',
         data: trends.value.map((item) => item.records),
         barMaxWidth: 18,
@@ -890,7 +926,7 @@ const trendOption = computed<ChartOption>(() => {
         itemStyle: { color: tokenColor },
       },
       {
-        name: '失败请求',
+        name: t('失败请求', 'Failed requests'),
         type: 'line',
         data: trends.value.map((item) => item.failed_records),
         showSymbol: true,
@@ -905,10 +941,10 @@ const trendOption = computed<ChartOption>(() => {
 const tokenBreakdownItems = computed<TokenBreakdownItem[]>(() => {
   const currentSummary = summary.value
   const values = [
-    { key: 'input', label: '输入 Token', value: currentSummary?.input_tokens ?? 0 },
-    { key: 'output', label: '输出 Token', value: currentSummary?.output_tokens ?? 0 },
-    { key: 'cached', label: '缓存 Token', value: currentSummary?.cached_tokens ?? 0 },
-    { key: 'reasoning', label: '推理 Token', value: currentSummary?.reasoning_tokens ?? 0 },
+    { key: 'input', label: t('输入 Token', 'Input tokens'), value: currentSummary?.input_tokens ?? 0 },
+    { key: 'output', label: t('输出 Token', 'Output tokens'), value: currentSummary?.output_tokens ?? 0 },
+    { key: 'cached', label: t('缓存 Token', 'Cached tokens'), value: currentSummary?.cached_tokens ?? 0 },
+    { key: 'reasoning', label: t('推理 Token', 'Reasoning tokens'), value: currentSummary?.reasoning_tokens ?? 0 },
   ]
   const total = values.reduce((sum, item) => sum + item.value, 0)
   return values.map((item, index) => ({
@@ -1052,7 +1088,10 @@ const hourActivityItems = computed<HourActivityItem[]>(() => {
       label: hourLabel,
       records: value.records,
       tokens: value.tokens,
-      recordTitle: `${hourLabel}:00 · ${formatInteger(value.records)} 次请求`,
+      recordTitle: t(
+        `${hourLabel}:00 · ${formatInteger(value.records)} 次请求`,
+        `${hourLabel}:00 · ${formatInteger(value.records)} requests`,
+      ),
       tokenTitle: `${hourLabel}:00 · ${formatCompact(value.tokens)} Token`,
       recordStyle: { '--heat-intensity': recordIntensity.toFixed(3) },
       tokenStyle: { '--heat-intensity': tokenIntensity.toFixed(3) },
@@ -1092,19 +1131,19 @@ const recentFailedRows = computed(() =>
 const anomalyStats = computed(() => [
   {
     key: 'failed_rate',
-    label: '失败率',
+    label: t('失败率', 'Failure rate'),
     value: formatPercent(failedRate.value),
     tone: failedRate.value > 0 ? 'danger' : 'success',
   },
   {
     key: 'failed_records',
-    label: '失败请求',
+    label: t('失败请求', 'Failed requests'),
     value: formatInteger(summary.value?.failed_records ?? failedSummary.value?.total_records ?? 0),
     tone: 'danger',
   },
   {
     key: 'unpriced',
-    label: '未计价',
+    label: t('未计价', 'Unpriced'),
     value: formatInteger(summary.value?.unpriced_records ?? 0),
     tone: (summary.value?.unpriced_records ?? 0) > 0 ? 'warning' : 'success',
   },
@@ -1118,10 +1157,10 @@ const endpointDistributionLegend = computed(() =>
 )
 
 const providerDistributionOption = computed<ChartOption>(() =>
-  distributionPieOption(distributions.value.providers, '服务商'),
+  distributionPieOption(distributions.value.providers, t('服务商', 'Providers')),
 )
 const endpointDistributionOption = computed<ChartOption>(() =>
-  distributionPieOption(distributions.value.endpoints, '接口'),
+  distributionPieOption(distributions.value.endpoints, t('接口', 'Endpoints')),
 )
 
 let autoRefreshTimer: number | undefined
@@ -1164,23 +1203,23 @@ onBeforeUnmount(() => {
         <span class="refresh-status" :class="{ 'is-error': autoRefreshError }">
           {{ refreshStatusText }}
         </span>
-        <NButton secondary @click="goRecords()">明细</NButton>
+        <NButton secondary @click="goRecords()">{{ t('明细', 'Records') }}</NButton>
       </div>
     </div>
 
     <section class="panel filter-panel" :class="{ 'is-expanded': filtersExpanded }">
       <div class="filter-summary">
         <div>
-          <strong>筛选</strong>
+          <strong>{{ t('筛选', 'Filters') }}</strong>
           <span>{{ dashboardRangeLabel }}</span>
         </div>
         <NButton class="filter-toggle" secondary size="small" @click="filtersExpanded = !filtersExpanded">
-          {{ filtersExpanded ? '收起' : '展开' }}
+          {{ filtersExpanded ? t('收起', 'Collapse') : t('展开', 'Expand') }}
         </NButton>
       </div>
       <div class="panel-inner filter-toolbar">
         <div class="time-row">
-          <div class="quick-ranges" role="group" aria-label="快捷时间范围">
+          <div class="quick-ranges" role="group" :aria-label="t('快捷时间范围', 'Quick time ranges')">
             <NButton
               v-for="option in quickRangeOptions"
               :key="option.key"
@@ -1208,7 +1247,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.users"
             clearable
             filterable
-            placeholder="用户昵称"
+            :placeholder="t('用户昵称', 'User nickname')"
             @update:value="handleUserChange"
           />
           <NSelect
@@ -1216,7 +1255,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.apiKeyDescriptions"
             clearable
             filterable
-            placeholder="KEY 描述"
+            :placeholder="t('KEY 描述', 'Key description')"
             @update:value="handleApiKeyChange"
           />
           <NSelect
@@ -1224,7 +1263,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.providers"
             clearable
             filterable
-            placeholder="服务商"
+            :placeholder="t('服务商', 'Provider')"
             @update:value="handleProviderChange"
           />
           <NSelect
@@ -1232,7 +1271,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.models"
             clearable
             filterable
-            placeholder="模型"
+            :placeholder="t('模型', 'Model')"
             @update:value="handleModelChange"
           />
           <NSelect
@@ -1240,21 +1279,17 @@ onBeforeUnmount(() => {
             :options="selectOptions.endpoints"
             clearable
             filterable
-            placeholder="接口"
+            :placeholder="t('接口', 'Endpoint')"
             @update:value="handleEndpointChange"
           />
           <div class="status-actions">
             <NSelect
               :value="filterForm.failed"
               class="status-select"
-              :options="[
-                { label: '全部', value: 'all' },
-                { label: '成功', value: 'success' },
-                { label: '失败', value: 'failed' },
-              ]"
+              :options="failedFilterOptions"
               @update:value="handleFailedChange"
             />
-            <NButton secondary :loading="isLoading" @click="refresh()">筛选</NButton>
+            <NButton secondary :loading="isLoading" @click="refresh()">{{ t('筛选', 'Filter') }}</NButton>
           </div>
         </div>
       </div>
@@ -1283,7 +1318,7 @@ onBeforeUnmount(() => {
         <div class="dashboard-top-grid">
           <ChartPanel
             class="usage-trend-panel area-trend"
-            title="用量趋势"
+            :title="t('用量趋势', 'Usage trend')"
             :option="trendOption"
             :empty="trends.length === 0"
             :loading="isLoading"
@@ -1291,13 +1326,13 @@ onBeforeUnmount(() => {
 
           <ChartPanel
             class="token-panel area-token"
-            title="Token 构成"
+            :title="t('Token 构成', 'Token breakdown')"
             :option="tokenBreakdownOption"
             :empty="tokenBreakdownTotal === 0"
             :loading="isLoading"
             :compact-footer="tokenBreakdownItems.length <= 1"
           >
-            <ol class="distribution-legend token-legend" aria-label="Token 构成图例">
+            <ol class="distribution-legend token-legend" :aria-label="t('Token 构成图例', 'Token breakdown legend')">
               <li
                 v-for="item in tokenBreakdownItems"
                 :key="item.key"
@@ -1321,18 +1356,18 @@ onBeforeUnmount(() => {
             <section class="panel heatmap-panel area-heatmap">
               <div class="panel-inner compact-panel-inner">
                 <div class="panel-heading-row">
-                  <h2 class="section-title">小时活跃（今日）</h2>
+                  <h2 class="section-title">{{ t('小时活跃（今日）', 'Hourly activity (today)') }}</h2>
                   <span class="panel-subtle-text">
-                    {{ auxiliaryError ? '辅助数据降级' : '请求数 / Token' }}
+                    {{ auxiliaryError ? t('辅助数据降级', 'Auxiliary data degraded') : t('请求数 / Token', 'Requests / tokens') }}
                   </span>
                 </div>
                 <div class="heatmap-groups">
                   <div class="heatmap-group is-records">
                     <div class="heatmap-group-heading">
-                      <span>请求数</span>
-                      <strong>{{ formatInteger(todayRecordTotal) }} 次</strong>
+                      <span>{{ t('请求数', 'Requests') }}</span>
+                      <strong>{{ t(`${formatInteger(todayRecordTotal)} 次`, `${formatInteger(todayRecordTotal)} requests`) }}</strong>
                     </div>
-                    <div class="hour-heatmap is-records" aria-label="今日请求数小时活跃热力图">
+                    <div class="hour-heatmap is-records" :aria-label="t('今日请求数小时活跃热力图', 'Today hourly request heatmap')">
                       <div
                         v-for="item in hourActivityItems"
                         :key="`records-${item.hour}`"
@@ -1350,7 +1385,7 @@ onBeforeUnmount(() => {
                       <span>Token</span>
                       <strong>{{ formatCompact(todayTokenTotal) }}</strong>
                     </div>
-                    <div class="hour-heatmap is-tokens" aria-label="今日 Token 小时活跃热力图">
+                    <div class="hour-heatmap is-tokens" :aria-label="t('今日 Token 小时活跃热力图', 'Today hourly token heatmap')">
                       <div
                         v-for="item in hourActivityItems"
                         :key="`tokens-${item.hour}`"
@@ -1365,19 +1400,19 @@ onBeforeUnmount(() => {
                   </div>
                 </div>
                 <div class="heatmap-scale">
-                  <span>低</span>
+                  <span>{{ t('低', 'Low') }}</span>
                   <div class="heatmap-scale-bars" aria-hidden="true">
                     <i class="is-records" />
                     <i class="is-tokens" />
                   </div>
-                  <span>高</span>
+                  <span>{{ t('高', 'High') }}</span>
                 </div>
               </div>
             </section>
 
             <ChartPanel
               class="distribution-panel area-provider"
-              title="服务商分布"
+              :title="t('服务商分布', 'Provider distribution')"
               :option="providerDistributionOption"
               :empty="distributions.providers.length === 0"
               :loading="isLoading"
@@ -1386,7 +1421,7 @@ onBeforeUnmount(() => {
               <ol
                 class="distribution-legend"
                 :class="{ 'is-single': providerDistributionLegend.length === 1 }"
-                aria-label="服务商分布图例"
+                :aria-label="t('服务商分布图例', 'Provider distribution legend')"
               >
                 <li
                   v-for="item in providerDistributionLegend"
@@ -1410,8 +1445,8 @@ onBeforeUnmount(() => {
             <section class="panel anomaly-panel area-anomaly">
               <div class="panel-inner compact-panel-inner">
                 <div class="panel-heading-row">
-                  <h2 class="section-title">异常概览</h2>
-                  <NButton size="small" quaternary @click="goRecords({ failed: true })">更多</NButton>
+                  <h2 class="section-title">{{ t('异常概览', 'Anomaly overview') }}</h2>
+                  <NButton size="small" quaternary @click="goRecords({ failed: true })">{{ t('更多', 'More') }}</NButton>
                 </div>
                 <div class="anomaly-stat-grid">
                   <div
@@ -1425,14 +1460,14 @@ onBeforeUnmount(() => {
                   </div>
                 </div>
                 <div class="top-failed-endpoint">
-                  <span>Top 失败接口</span>
-                  <strong :title="topFailedEndpoint?.label ?? '暂无失败接口'">
-                    {{ topFailedEndpoint?.label ?? '暂无失败接口' }}
+                  <span>{{ t('Top 失败接口', 'Top failed endpoint') }}</span>
+                  <strong :title="topFailedEndpoint?.label ?? t('暂无失败接口', 'No failed endpoints')">
+                    {{ topFailedEndpoint?.label ?? t('暂无失败接口', 'No failed endpoints') }}
                   </strong>
                 </div>
                 <div class="recent-failed-list">
                   <div v-if="recentFailedRows.length === 0" class="empty-inline">
-                    当前范围暂无失败请求
+                    {{ t('当前范围暂无失败请求', 'No failed requests in the current range') }}
                   </div>
                   <button
                     v-for="item in recentFailedRows"
@@ -1443,7 +1478,7 @@ onBeforeUnmount(() => {
                     @click="goRecords({ failed: true })"
                   >
                     <span>{{ formatTrendBucket(item.bucket) }}</span>
-                    <strong>{{ formatInteger(item.records) }} 次</strong>
+                    <strong>{{ t(`${formatInteger(item.records)} 次`, `${formatInteger(item.records)} requests`) }}</strong>
                     <em>{{ formatCompact(item.total_tokens) }} Token</em>
                   </button>
                 </div>
@@ -1452,7 +1487,7 @@ onBeforeUnmount(() => {
 
             <ChartPanel
               class="distribution-panel area-endpoint"
-              title="接口分布"
+              :title="t('接口分布', 'Endpoint distribution')"
               :option="endpointDistributionOption"
               :empty="distributions.endpoints.length === 0"
               :loading="isLoading"
@@ -1461,7 +1496,7 @@ onBeforeUnmount(() => {
               <ol
                 class="distribution-legend"
                 :class="{ 'is-single': endpointDistributionLegend.length === 1 }"
-                aria-label="接口分布图例"
+                :aria-label="t('接口分布图例', 'Endpoint distribution legend')"
               >
                 <li
                   v-for="item in endpointDistributionLegend"
@@ -1486,10 +1521,10 @@ onBeforeUnmount(() => {
               <div class="panel-inner compact-panel-inner">
                 <div class="panel-heading-row">
                   <h2 class="section-title">{{ rankingTitle }}</h2>
-                  <span class="panel-subtle-text">按 Token 排序</span>
+                  <span class="panel-subtle-text">{{ t('按 Token 排序', 'Sorted by tokens') }}</span>
                 </div>
                 <div class="ranking-list">
-                  <div v-if="primaryRankingRows.length === 0" class="empty-inline">暂无排行数据</div>
+                  <div v-if="primaryRankingRows.length === 0" class="empty-inline">{{ t('暂无排行数据', 'No ranking data') }}</div>
                   <div
                     v-for="(row, index) in primaryRankingRows"
                     v-else
@@ -1507,10 +1542,10 @@ onBeforeUnmount(() => {
                     </div>
                     <div class="ranking-values">
                       <strong>{{ formatCompact(row.total_tokens) }}</strong>
-                      <span>{{ formatInteger(row.records) }} 次</span>
+                      <span>{{ t(`${formatInteger(row.records)} 次`, `${formatInteger(row.records)} requests`) }}</span>
                     </div>
                     <NButton size="tiny" quaternary @click="goRecords(rankingFilters(row))">
-                      明细
+                      {{ t('明细', 'Records') }}
                     </NButton>
                   </div>
                 </div>
@@ -1520,11 +1555,11 @@ onBeforeUnmount(() => {
             <section class="panel ranking-panel area-model-ranking">
               <div class="panel-inner compact-panel-inner">
                 <div class="panel-heading-row">
-                  <h2 class="section-title">模型排行</h2>
-                  <span class="panel-subtle-text">按 Token 排序</span>
+                  <h2 class="section-title">{{ t('模型排行', 'Model ranking') }}</h2>
+                  <span class="panel-subtle-text">{{ t('按 Token 排序', 'Sorted by tokens') }}</span>
                 </div>
                 <div class="ranking-list">
-                  <div v-if="modelRankingRows.length === 0" class="empty-inline">暂无模型数据</div>
+                  <div v-if="modelRankingRows.length === 0" class="empty-inline">{{ t('暂无模型数据', 'No model data') }}</div>
                   <div
                     v-for="(row, index) in modelRankingRows"
                     v-else
@@ -1542,10 +1577,10 @@ onBeforeUnmount(() => {
                     </div>
                     <div class="ranking-values">
                       <strong>{{ formatCompact(row.total_tokens) }}</strong>
-                      <span>{{ formatInteger(row.records) }} 次</span>
+                      <span>{{ t(`${formatInteger(row.records)} 次`, `${formatInteger(row.records)} requests`) }}</span>
                     </div>
                     <NButton size="tiny" quaternary @click="goRecords(modelFilters(row))">
-                      明细
+                      {{ t('明细', 'Records') }}
                     </NButton>
                   </div>
                 </div>

--- a/frontend/src/features/usage/views/UsageRecordsView.vue
+++ b/frontend/src/features/usage/views/UsageRecordsView.vue
@@ -29,6 +29,7 @@ import {
   formatUsd,
   jsonPretty,
 } from '@/shared/utils/format'
+import { useI18n } from '@/shared/i18n'
 
 type FailedFilter = 'all' | 'success' | 'failed'
 type QuickRangeKey = 'today' | 'last24h' | 'last3d' | 'last7d' | 'all'
@@ -81,19 +82,13 @@ const ACCOUNT_RECORDS_TABLE_SCROLL_X =
   RECORDS_TABLE_COLUMN_WIDTHS.user -
   RECORDS_TABLE_COLUMN_WIDTHS.source
 const RECORDS_TABLE_FALLBACK_MAX_HEIGHT = 'max(320px, calc(100dvh - 318px))'
-const quickRangeOptions: Array<{ key: QuickRangeKey; label: string }> = [
-  { key: 'today', label: '今日' },
-  { key: 'last24h', label: '近24小时' },
-  { key: 'last3d', label: '近3日' },
-  { key: 'last7d', label: '近7日' },
-  { key: 'all', label: '全部' },
-]
 const desktopRecordsLayoutQuery = window.matchMedia('(min-width: 861px)')
 
 const route = useRoute()
 const router = useRouter()
 const message = useMessage()
 const props = defineProps<Props>()
+const { currentLanguage, errorText, t } = useI18n()
 const isLoading = ref(false)
 const isAutoRefreshing = ref(false)
 const autoRefreshError = ref<string | null>(null)
@@ -177,6 +172,20 @@ const filterForm = reactive({
   endpoint: typeof route.query.endpoint === 'string' ? route.query.endpoint : null,
   failed: failedFromQuery(),
 })
+
+const quickRangeOptions = computed<Array<{ key: QuickRangeKey; label: string }>>(() => [
+  { key: 'today', label: t('今日', 'Today') },
+  { key: 'last24h', label: t('近24小时', 'Last 24 hours') },
+  { key: 'last3d', label: t('近3日', 'Last 3 days') },
+  { key: 'last7d', label: t('近7日', 'Last 7 days') },
+  { key: 'all', label: t('全部', 'All') },
+])
+
+const failedFilterOptions = computed(() => [
+  { label: t('全部', 'All'), value: 'all' },
+  { label: t('成功', 'Success'), value: 'success' },
+  { label: t('失败', 'Failed'), value: 'failed' },
+])
 
 function apiKeyFilterLabel(item: UsageOptionsResponse['api_key_descriptions'][number]): string {
   return item.label?.trim() || item.key
@@ -274,11 +283,16 @@ const selectOptions = computed(() => ({
 }))
 
 const isAccountScope = computed(() => props.scope === 'account')
-const pageTitle = computed(() => (isAccountScope.value ? '我的明细' : '请求明细'))
+const pageTitle = computed(() =>
+  isAccountScope.value ? t('我的明细', 'My records') : t('请求明细', 'Request records'),
+)
 const pageSubtitle = computed(() =>
   isAccountScope.value
-    ? '仅查询当前登录账号自己的本地用量记录'
-    : '分页查询本地用量记录，单条原始数据已在接口层脱敏',
+    ? t('仅查询当前登录账号自己的本地用量记录', 'Only local usage records for your account are shown')
+    : t(
+        '分页查询本地用量记录，单条原始数据已在接口层脱敏',
+        'Browse local usage records by page. Raw record data is masked by the API.',
+      ),
 )
 const recordsTableScrollX = computed(() =>
   isAccountScope.value ? ACCOUNT_RECORDS_TABLE_SCROLL_X : ADMIN_RECORDS_TABLE_SCROLL_X,
@@ -292,17 +306,19 @@ const recordsTableLayoutProps = computed<RecordsTableLayoutProps>(() =>
 const refreshStatusText = computed(() => {
   const lastRefreshTime = lastRefreshedAt.value
   if (!lastRefreshTime) {
-    return autoRefreshError.value ? '自动刷新异常 · 尚无成功同步' : '每 5 秒自动刷新 · 等待首次同步'
+    return autoRefreshError.value
+      ? t('自动刷新异常 · 尚无成功同步', 'Auto refresh error · no successful sync yet')
+      : t('每 5 秒自动刷新 · 等待首次同步', 'Auto refresh every 5 seconds · waiting for first sync')
   }
-  const lastRefreshText = new Intl.DateTimeFormat('zh-CN', {
+  const lastRefreshText = new Intl.DateTimeFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
   }).format(lastRefreshTime)
   if (autoRefreshError.value) {
-    return `自动刷新异常 · 最近成功 ${lastRefreshText}`
+    return t(`自动刷新异常 · 最近成功 ${lastRefreshText}`, `Auto refresh error · last success ${lastRefreshText}`)
   }
-  return `每 5 秒自动刷新 · 最近 ${lastRefreshText}`
+  return t(`每 5 秒自动刷新 · 最近 ${lastRefreshText}`, `Auto refresh every 5 seconds · latest ${lastRefreshText}`)
 })
 
 function buildFilters(): UsageFilters {
@@ -502,7 +518,7 @@ async function refresh({ resetPage = false, silent = false }: RefreshOptions = {
     autoRefreshError.value = null
     lastRefreshedAt.value = new Date()
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : '加载明细失败'
+    const errorMessage = errorText(error, '加载明细失败', 'Failed to load records')
     if (silent) {
       autoRefreshError.value = errorMessage
     } else {
@@ -527,7 +543,7 @@ async function openRecord(record: UsageRecordListItem) {
     selectedRecord.value = await getUsageRecord(record.id, props.scope)
     drawerOpen.value = true
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载原始数据失败')
+    message.error(errorText(error, '加载原始数据失败', 'Failed to load raw data'))
   }
 }
 
@@ -539,7 +555,7 @@ function textOrDash(value: string | null | undefined): string {
 function userLabel(value: string | null | undefined): string {
   const normalized = value?.trim()
   if (!normalized || normalized === '未绑定') {
-    return '未知'
+    return t('未知', 'Unknown')
   }
   return normalized
 }
@@ -586,7 +602,7 @@ function renderUserLabel(row: UsageRecordListItem) {
 
 function apiKeyDescriptionLabel(value: string | null | undefined): string {
   const normalized = value?.trim()
-  return normalized || '未知'
+  return normalized || t('未知', 'Unknown')
 }
 
 function formatLatency(value: number | null): string {
@@ -619,7 +635,7 @@ function formatOutputTps(row: Pick<UsageRecordListItem, 'latency_ms' | 'output_t
     return '-'
   }
   const tokensPerSecond = (row.output_tokens / row.latency_ms) * 1000
-  return new Intl.NumberFormat('zh-CN', {
+  return new Intl.NumberFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     maximumFractionDigits: tokensPerSecond < 10 ? 2 : 1,
   }).format(tokensPerSecond)
 }
@@ -668,7 +684,10 @@ function isClaudeProvider(provider: string | null | undefined): boolean {
 
 function formatCacheTokens(row: UsageRecordListItem): string {
   if (isClaudeProvider(row.provider)) {
-    return `(读 ${formatInteger(row.cache_read_tokens)} / 写 ${formatInteger(row.cache_creation_tokens)})`
+    return t(
+      `(读 ${formatInteger(row.cache_read_tokens)} / 写 ${formatInteger(row.cache_creation_tokens)})`,
+      `(read ${formatInteger(row.cache_read_tokens)} / write ${formatInteger(row.cache_creation_tokens)})`,
+    )
   }
   return formatInteger(row.cached_tokens)
 }
@@ -687,31 +706,31 @@ const detailRows = computed(() => {
     return []
   }
   const rows = [
-    { label: '时间', value: formatDateTime(record.timestamp) },
-    { label: '模型', value: formatModelWithReasoning(record) },
-    { label: '服务商', value: textOrDash(record.provider) },
-    { label: '接口', value: textOrDash(record.endpoint) },
-    { label: 'API KEY 描述', value: apiKeyDescriptionLabel(record.api_key_description) },
-    { label: '认证类型', value: textOrDash(record.auth) },
-    { label: '请求 ID', value: textOrDash(record.request_id) },
-    { label: '结果', value: record.failed ? '失败' : '成功' },
-    { label: '首字耗时', value: formatPositiveLatency(record.ttft_ms) },
-    { label: '总耗时', value: formatLatency(record.latency_ms) },
-    { label: '输入 Token', value: formatInteger(record.input_tokens) },
-    { label: '缓存 Token', value: formatInteger(record.cached_tokens) },
-    { label: '缓存读 Token', value: formatInteger(record.cache_read_tokens) },
-    { label: '缓存写 Token', value: formatInteger(record.cache_creation_tokens) },
-    { label: '输出 Token', value: formatOutputWithTps(record) },
-    { label: '思考 Token', value: formatInteger(record.reasoning_tokens) },
-    { label: '总 Token', value: formatInteger(record.total_tokens) },
-    { label: '费用', value: formatUsd(record.estimated_cost_usd) },
+    { label: t('时间', 'Time'), value: formatDateTime(record.timestamp) },
+    { label: t('模型', 'Model'), value: formatModelWithReasoning(record) },
+    { label: t('服务商', 'Provider'), value: textOrDash(record.provider) },
+    { label: t('接口', 'Endpoint'), value: textOrDash(record.endpoint) },
+    { label: t('API KEY 描述', 'API key description'), value: apiKeyDescriptionLabel(record.api_key_description) },
+    { label: t('认证类型', 'Auth type'), value: textOrDash(record.auth) },
+    { label: t('请求 ID', 'Request ID'), value: textOrDash(record.request_id) },
+    { label: t('结果', 'Result'), value: record.failed ? t('失败', 'Failed') : t('成功', 'Success') },
+    { label: t('首字耗时', 'TTFT'), value: formatPositiveLatency(record.ttft_ms) },
+    { label: t('总耗时', 'Latency'), value: formatLatency(record.latency_ms) },
+    { label: t('输入 Token', 'Input tokens'), value: formatInteger(record.input_tokens) },
+    { label: t('缓存 Token', 'Cached tokens'), value: formatInteger(record.cached_tokens) },
+    { label: t('缓存读 Token', 'Cache read tokens'), value: formatInteger(record.cache_read_tokens) },
+    { label: t('缓存写 Token', 'Cache write tokens'), value: formatInteger(record.cache_creation_tokens) },
+    { label: t('输出 Token', 'Output tokens'), value: formatOutputWithTps(record) },
+    { label: t('思考 Token', 'Reasoning tokens'), value: formatInteger(record.reasoning_tokens) },
+    { label: t('总 Token', 'Total tokens'), value: formatInteger(record.total_tokens) },
+    { label: t('费用', 'Cost'), value: formatUsd(record.estimated_cost_usd) },
   ]
   if (!isAccountScope.value) {
     rows.splice(
       4,
       0,
-      { label: '来源', value: textOrDash(record.source) },
-      { label: '用户昵称', value: userLabel(record.user_label) },
+      { label: t('来源', 'Source'), value: textOrDash(record.source) },
+      { label: t('用户昵称', 'User nickname'), value: userLabel(record.user_label) },
     )
   }
   return rows
@@ -719,7 +738,7 @@ const detailRows = computed(() => {
 
 const columns = computed<DataTableColumns<UsageRecordListItem>>(() => [
   {
-    title: '时间',
+    title: t('时间', 'Time'),
     key: 'timestamp',
     width: RECORDS_TABLE_COLUMN_WIDTHS.timestamp,
     render: (row) => formatDateTime(row.timestamp),
@@ -728,7 +747,7 @@ const columns = computed<DataTableColumns<UsageRecordListItem>>(() => [
     ? []
     : [
         {
-          title: '用户昵称',
+          title: t('用户昵称', 'User nickname'),
           key: 'user_label',
           width: RECORDS_TABLE_COLUMN_WIDTHS.user,
           ellipsis: { tooltip: true },
@@ -736,14 +755,14 @@ const columns = computed<DataTableColumns<UsageRecordListItem>>(() => [
         },
       ]),
   {
-    title: 'KEY 描述',
+    title: t('KEY 描述', 'Key description'),
     key: 'api_key_description',
     width: RECORDS_TABLE_COLUMN_WIDTHS.apiKeyDescription,
     ellipsis: { tooltip: true },
     render: (row) => apiKeyDescriptionLabel(row.api_key_description),
   },
   {
-    title: '模型',
+    title: t('模型', 'Model'),
     key: 'model',
     width: RECORDS_TABLE_COLUMN_WIDTHS.model,
     ellipsis: { tooltip: true },
@@ -753,85 +772,85 @@ const columns = computed<DataTableColumns<UsageRecordListItem>>(() => [
     ? []
     : [
         {
-          title: '来源',
+          title: t('来源', 'Source'),
           key: 'source',
           width: RECORDS_TABLE_COLUMN_WIDTHS.source,
           ellipsis: { tooltip: true },
         },
       ]),
   {
-    title: '结果',
+    title: t('结果', 'Result'),
     key: 'failed',
     width: RECORDS_TABLE_COLUMN_WIDTHS.failed,
     render: (row) =>
       h(
         NTag,
         { type: row.failed ? 'error' : 'success', size: 'small', bordered: false },
-        { default: () => (row.failed ? '失败' : '成功') },
+        { default: () => (row.failed ? t('失败', 'Failed') : t('成功', 'Success')) },
       ),
   },
   {
-    title: '首字耗时',
+    title: t('首字耗时', 'TTFT'),
     key: 'ttft_ms',
     width: RECORDS_TABLE_COLUMN_WIDTHS.ttft,
     render: (row) => formatPositiveLatency(row.ttft_ms),
   },
   {
-    title: '总耗时',
+    title: t('总耗时', 'Latency'),
     key: 'latency_ms',
     width: RECORDS_TABLE_COLUMN_WIDTHS.latency,
     render: (row) => formatLatency(row.latency_ms),
   },
   {
-    title: '输入',
+    title: t('输入', 'Input'),
     key: 'input_tokens',
     width: RECORDS_TABLE_COLUMN_WIDTHS.inputTokens,
     render: (row) => formatInteger(row.input_tokens),
   },
   {
-    title: '输出',
+    title: t('输出', 'Output'),
     key: 'output_tokens',
     width: RECORDS_TABLE_COLUMN_WIDTHS.outputTokens,
     render: renderOutputWithTps,
   },
   {
-    title: '思考',
+    title: t('思考', 'Reasoning'),
     key: 'reasoning_tokens',
     width: RECORDS_TABLE_COLUMN_WIDTHS.reasoningTokens,
     render: (row) => formatInteger(row.reasoning_tokens),
   },
   {
-    title: '缓存',
+    title: t('缓存', 'Cache'),
     key: 'cached_tokens',
     width: RECORDS_TABLE_COLUMN_WIDTHS.cachedTokens,
     render: formatCacheTokens,
   },
   {
-    title: '总 Token',
+    title: t('总 Token', 'Total tokens'),
     key: 'total_tokens',
     width: RECORDS_TABLE_COLUMN_WIDTHS.totalTokens,
     render: (row) => formatInteger(row.total_tokens),
   },
   {
-    title: '费用',
+    title: t('费用', 'Cost'),
     key: 'estimated_cost_usd',
     width: RECORDS_TABLE_COLUMN_WIDTHS.estimatedCost,
     render: (row) => formatUsd(row.estimated_cost_usd),
   },
   {
-    title: '服务商',
+    title: t('服务商', 'Provider'),
     key: 'provider',
     width: RECORDS_TABLE_COLUMN_WIDTHS.provider,
     ellipsis: { tooltip: true },
   },
   {
-    title: '接口',
+    title: t('接口', 'Endpoint'),
     key: 'endpoint',
     width: RECORDS_TABLE_COLUMN_WIDTHS.endpoint,
     ellipsis: { tooltip: true },
   },
   {
-    title: '请求 ID',
+    title: t('请求 ID', 'Request ID'),
     key: 'request_id',
     width: RECORDS_TABLE_COLUMN_WIDTHS.requestId,
     ellipsis: { tooltip: true },
@@ -845,7 +864,7 @@ const columns = computed<DataTableColumns<UsageRecordListItem>>(() => [
       h(
         NButton,
         { size: 'small', quaternary: true, onClick: () => void openRecord(row) },
-        { default: () => '详情' },
+        { default: () => t('详情', 'Details') },
       ),
   },
 ])
@@ -885,7 +904,7 @@ onBeforeUnmount(() => {
     <section class="panel">
       <div class="panel-inner filter-toolbar">
         <div class="time-row">
-          <div class="quick-ranges" role="group" aria-label="快捷时间范围">
+          <div class="quick-ranges" role="group" :aria-label="t('快捷时间范围', 'Quick time ranges')">
             <NButton
               v-for="option in quickRangeOptions"
               :key="option.key"
@@ -913,7 +932,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.users"
             clearable
             filterable
-            placeholder="用户昵称"
+            :placeholder="t('用户昵称', 'User nickname')"
             @update:value="handleUserChange"
           />
           <NSelect
@@ -921,7 +940,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.apiKeyDescriptions"
             clearable
             filterable
-            placeholder="KEY 描述"
+            :placeholder="t('KEY 描述', 'Key description')"
             @update:value="handleApiKeyChange"
           />
           <NSelect
@@ -929,7 +948,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.providers"
             clearable
             filterable
-            placeholder="服务商"
+            :placeholder="t('服务商', 'Provider')"
             @update:value="handleProviderChange"
           />
           <NSelect
@@ -937,7 +956,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.models"
             clearable
             filterable
-            placeholder="模型"
+            :placeholder="t('模型', 'Model')"
             @update:value="handleModelChange"
           />
           <NSelect
@@ -946,7 +965,7 @@ onBeforeUnmount(() => {
             :options="selectOptions.sources"
             clearable
             filterable
-            placeholder="来源"
+            :placeholder="t('来源', 'Source')"
             @update:value="handleSourceChange"
           />
           <NSelect
@@ -954,22 +973,18 @@ onBeforeUnmount(() => {
             :options="selectOptions.endpoints"
             clearable
             filterable
-            placeholder="接口"
+            :placeholder="t('接口', 'Endpoint')"
             @update:value="handleEndpointChange"
           />
           <div class="status-actions">
             <NSelect
               :value="filterForm.failed"
               class="status-select"
-              :options="[
-                { label: '全部', value: 'all' },
-                { label: '成功', value: 'success' },
-                { label: '失败', value: 'failed' },
-              ]"
+              :options="failedFilterOptions"
               @update:value="handleFailedChange"
             />
             <NButton secondary :loading="isLoading" @click="refresh({ resetPage: true })">
-              筛选
+              {{ t('筛选', 'Filter') }}
             </NButton>
           </div>
         </div>
@@ -1006,15 +1021,15 @@ onBeforeUnmount(() => {
     </section>
 
     <NDrawer v-model:show="drawerOpen" placement="right" width="min(760px, 100vw)">
-      <NDrawerContent title="请求事件详情">
-        <h3 class="drawer-section-title">结构化信息</h3>
+      <NDrawerContent :title="t('请求事件详情', 'Request event details')">
+        <h3 class="drawer-section-title">{{ t('结构化信息', 'Structured information') }}</h3>
         <div class="detail-grid">
           <div v-for="row in detailRows" :key="row.label" class="detail-item">
             <div class="detail-label">{{ row.label }}</div>
             <div class="detail-value">{{ row.value }}</div>
           </div>
         </div>
-        <h3 class="drawer-section-title">原始数据</h3>
+        <h3 class="drawer-section-title">{{ t('原始数据', 'Raw data') }}</h3>
         <pre class="mono-json">{{ jsonPretty(selectedRecord?.raw_json ?? {}) }}</pre>
       </NDrawerContent>
     </NDrawer>

--- a/frontend/src/features/users/views/UserManagementView.vue
+++ b/frontend/src/features/users/views/UserManagementView.vue
@@ -27,10 +27,12 @@ import {
   updateUser,
   updateUserQuota,
 } from '@/features/users/api/usersApi'
+import { useI18n } from '@/shared/i18n'
 import type { UserSummary } from '@/shared/types/api'
 import { formatCompact, formatDateTime, formatInteger, formatUsd } from '@/shared/utils/format'
 
 const message = useMessage()
+const { errorText, t } = useI18n()
 const isLoading = ref(false)
 const isSavingUser = ref(false)
 const users = ref<UserSummary[]>([])
@@ -62,33 +64,33 @@ const userMetrics = computed<UserMetricCard[]>(() => {
   return [
     {
       key: 'active',
-      label: '启用用户',
+      label: t('启用用户', 'Active users'),
       value: formatInteger(activeUsers),
-      footnote: `共 ${formatInteger(users.value.length)} 个账号`,
+      footnote: t(`共 ${formatInteger(users.value.length)} 个账号`, `${formatInteger(users.value.length)} accounts total`),
       tone: 'teal',
       icon: UserRound,
     },
     {
       key: 'admins',
-      label: '管理员',
+      label: t('管理员', 'Admins'),
       value: formatInteger(adminUsers),
-      footnote: '拥有管理权限',
+      footnote: t('拥有管理权限', 'Have admin access'),
       tone: 'purple',
       icon: ShieldCheck,
     },
     {
       key: 'keys',
-      label: '绑定 Key',
+      label: t('绑定 Key', 'Bound keys'),
       value: formatInteger(boundKeys),
-      footnote: '当前用户集合',
+      footnote: t('当前用户集合', 'Current users'),
       tone: 'blue',
       icon: KeyRound,
     },
     {
       key: 'cost',
-      label: '今日费用',
+      label: t('今日费用', 'Today cost'),
       value: formatUsd(todayCost),
-      footnote: '按现价估算',
+      footnote: t('按现价估算', 'Estimated at current prices'),
       tone: 'green',
       icon: CircleDollarSign,
     },
@@ -96,12 +98,12 @@ const userMetrics = computed<UserMetricCard[]>(() => {
 })
 
 function userLabel(row: UserSummary): string {
-  return row.nickname.trim() || row.username.trim() || '未知用户'
+  return row.nickname.trim() || row.username.trim() || t('未知用户', 'Unknown user')
 }
 
 function quotaBalanceValue(row: UserSummary, bucket: 'monthly' | 'lifetime'): string {
   if (row.quota.unlimited) {
-    return '无限制'
+    return t('无限制', 'Unlimited')
   }
 
   const value = bucket === 'monthly' ? row.quota.monthly_remaining_usd : row.quota.lifetime_remaining_usd
@@ -120,36 +122,36 @@ function quotaBalanceClass(row: UserSummary): string {
 
 function quotaDetail(row: UserSummary): string | null {
   if (row.quota.paused) {
-    return 'Key 已因余额暂停'
+    return t('Key 已因余额暂停', 'Keys paused due to balance')
   }
   if (row.quota.sync_error) {
-    return '同步异常'
+    return t('同步异常', 'Sync error')
   }
   if (row.quota.unpriced_records > 0) {
-    return `未定价 ${formatInteger(row.quota.unpriced_records)} 条`
+    return t(`未定价 ${formatInteger(row.quota.unpriced_records)} 条`, `${formatInteger(row.quota.unpriced_records)} unpriced`)
   }
   return null
 }
 
 function todayRequestDetail(row: UserSummary): string {
   if (!row.today_records) {
-    return `累计 ${formatInteger(row.records)}`
+    return t(`累计 ${formatInteger(row.records)}`, `${formatInteger(row.records)} total`)
   }
   const failed = row.today_failed_records
-    ? `失败 ${formatInteger(row.today_failed_records)}`
-    : '无失败'
+    ? t(`失败 ${formatInteger(row.today_failed_records)}`, `${formatInteger(row.today_failed_records)} failed`)
+    : t('无失败', 'No failures')
   const rate = Math.round((row.today_success_records / row.today_records) * 100)
   return `${rate}% · ${failed}`
 }
 
 function todayCostDetail(row: UserSummary): string {
   if (!row.today_records) {
-    return '今日无请求'
+    return t('今日无请求', 'No requests today')
   }
   if (row.today_unpriced_records > 0) {
-    return `未计价 ${formatInteger(row.today_unpriced_records)}`
+    return t(`未计价 ${formatInteger(row.today_unpriced_records)}`, `${formatInteger(row.today_unpriced_records)} unpriced`)
   }
-  return '已计价'
+  return t('已计价', 'Priced')
 }
 
 function lastModelLabel(row: UserSummary): string {
@@ -157,7 +159,7 @@ function lastModelLabel(row: UserSummary): string {
 }
 
 function lastProviderLabel(row: UserSummary): string {
-  return row.last_provider ?? '未知服务商'
+  return row.last_provider ?? t('未知服务商', 'Unknown provider')
 }
 
 function setQuotaLifetimeUsd(value: number | null) {
@@ -202,7 +204,7 @@ async function refresh() {
   try {
     users.value = await listUsers()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '加载用户列表失败')
+    message.error(errorText(error, '加载用户列表失败', 'Failed to load users'))
   } finally {
     isLoading.value = false
   }
@@ -215,38 +217,38 @@ function isUserDisabled(row: UserSummary): boolean {
 async function disableUserRow(row: UserSummary) {
   try {
     await disableUser(row.id)
-    message.success('用户已禁用')
+    message.success(t('用户已禁用', 'User disabled'))
     await refresh()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '禁用用户失败')
+    message.error(errorText(error, '禁用用户失败', 'Failed to disable user'))
   }
 }
 
 async function enableUserRow(row: UserSummary) {
   try {
     await enableUser(row.id)
-    message.success('用户已启用')
+    message.success(t('用户已启用', 'User enabled'))
     await refresh()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '启用用户失败')
+    message.error(errorText(error, '启用用户失败', 'Failed to enable user'))
   }
 }
 
 async function saveUser() {
   const nickname = userNickname.value.trim()
   if (!nickname) {
-    message.error('用户昵称不能为空')
+    message.error(t('用户昵称不能为空', 'User nickname is required'))
     return
   }
   const username = userAccount.value.trim()
   if (!username) {
-    message.error('账号不能为空')
+    message.error(t('账号不能为空', 'Account is required'))
     return
   }
   const isEditing = editingUserId.value !== null
   const password = userPassword.value.trim()
   if (!isEditing && !password) {
-    message.error('密码不能为空')
+    message.error(t('密码不能为空', 'Password is required'))
     return
   }
   isSavingUser.value = true
@@ -265,38 +267,38 @@ async function saveUser() {
       lifetime_quota_usd: quotaUnlimited.value ? null : quotaLifetimeUsd.value,
       monthly_quota_usd: quotaUnlimited.value ? null : quotaMonthlyUsd.value,
     })
-    message.success(isEditing ? '用户已保存' : '用户已创建')
+    message.success(isEditing ? t('用户已保存', 'User saved') : t('用户已创建', 'User created'))
     editorVisible.value = false
     resetEditor()
     await refresh()
   } catch (error) {
-    message.error(error instanceof Error ? error.message : '保存用户失败')
+    message.error(errorText(error, '保存用户失败', 'Failed to save user'))
   } finally {
     isSavingUser.value = false
   }
 }
 
-const columns: DataTableColumns<UserSummary> = [
+const columns = computed<DataTableColumns<UserSummary>>(() => [
   {
-    title: '用户昵称',
+    title: t('用户昵称', 'User nickname'),
     key: 'nickname',
     width: 120,
     render: (row) => userLabel(row),
   },
   {
-    title: '账号',
+    title: t('账号', 'Account'),
     key: 'username',
     width: 130,
     render: (row) => row.username,
   },
   {
-    title: '角色',
+    title: t('角色', 'Role'),
     key: 'is_admin',
     width: 90,
-    render: (row) => (row.is_admin ? '管理员' : '普通用户'),
+    render: (row) => (row.is_admin ? t('管理员', 'Admin') : t('普通用户', 'Standard user')),
   },
   {
-    title: '状态',
+    title: t('状态', 'Status'),
     key: 'disabled_at',
     width: 90,
     render: (row) =>
@@ -307,22 +309,22 @@ const columns: DataTableColumns<UserSummary> = [
           type: isUserDisabled(row) ? 'warning' : 'success',
           bordered: false,
         },
-        { default: () => (isUserDisabled(row) ? '已禁用' : '启用中') },
+        { default: () => (isUserDisabled(row) ? t('已禁用', 'Disabled') : t('启用中', 'Enabled')) },
       ),
   },
   {
-    title: '余额',
+    title: t('余额', 'Balance'),
     key: 'quota',
     width: 210,
     render: (row) => {
       const detail = quotaDetail(row)
       return h('div', { class: ['metric-stack', 'quota-balance-stack'] }, [
         h('div', { class: ['quota-balance-row', 'is-monthly', quotaBalanceClass(row)] }, [
-          h('span', { class: 'quota-balance-label' }, '每月余额：'),
+          h('span', { class: 'quota-balance-label' }, t('每月余额：', 'Monthly: ')),
           h('strong', { class: 'quota-balance-value' }, quotaBalanceValue(row, 'monthly')),
         ]),
         h('div', { class: ['quota-balance-row', 'is-lifetime', quotaBalanceClass(row)] }, [
-          h('span', { class: 'quota-balance-label' }, '不限时余额：'),
+          h('span', { class: 'quota-balance-label' }, t('不限时余额：', 'Lifetime: ')),
           h('strong', { class: 'quota-balance-value' }, quotaBalanceValue(row, 'lifetime')),
         ]),
         ...(detail
@@ -338,13 +340,13 @@ const columns: DataTableColumns<UserSummary> = [
     },
   },
   {
-    title: 'API KEY',
+    title: t('API KEY 数量', 'API keys'),
     key: 'key_count',
     width: 95,
-    render: (row) => `${formatInteger(row.key_count)} 个`,
+    render: (row) => t(`${formatInteger(row.key_count)} 个`, `${formatInteger(row.key_count)} keys`),
   },
   {
-    title: '今日请求',
+    title: t('今日请求', 'Today requests'),
     key: 'today_records',
     width: 140,
     render: (row) =>
@@ -354,31 +356,31 @@ const columns: DataTableColumns<UserSummary> = [
       ]),
   },
   {
-    title: '今日输入',
+    title: t('今日输入', 'Today input'),
     key: 'today_input_tokens',
     width: 120,
     render: (row) => formatCompact(row.today_input_tokens),
   },
   {
-    title: '今日输出',
+    title: t('今日输出', 'Today output'),
     key: 'today_output_tokens',
     width: 120,
     render: (row) => formatCompact(row.today_output_tokens),
   },
   {
-    title: '今日缓存',
+    title: t('今日缓存', 'Today cache'),
     key: 'today_cached_tokens',
     width: 120,
     render: (row) => formatCompact(row.today_cached_tokens),
   },
   {
-    title: '今日总 Token',
+    title: t('今日总 Token', 'Today total tokens'),
     key: 'today_total_tokens',
     width: 145,
     render: (row) => formatCompact(row.today_total_tokens),
   },
   {
-    title: '今日费用',
+    title: t('今日费用', 'Today cost'),
     key: 'today_estimated_cost_usd',
     width: 150,
     render: (row) =>
@@ -392,7 +394,7 @@ const columns: DataTableColumns<UserSummary> = [
       ]),
   },
   {
-    title: '最近模型',
+    title: t('最近模型', 'Recent model'),
     key: 'last_model',
     width: 160,
     render: (row) =>
@@ -402,7 +404,7 @@ const columns: DataTableColumns<UserSummary> = [
       ]),
   },
   {
-    title: '最近使用',
+    title: t('最近使用', 'Last used'),
     key: 'last_seen_at',
     width: 150,
     render: (row) => formatDateTime(row.last_seen_at),
@@ -421,7 +423,7 @@ const columns: DataTableColumns<UserSummary> = [
             h(
               NButton,
               { size: 'small', quaternary: true, onClick: () => editUser(row) },
-              { default: () => '编辑' },
+              { default: () => t('编辑', 'Edit') },
             ),
             row.id === 1
               ? null
@@ -434,9 +436,9 @@ const columns: DataTableColumns<UserSummary> = [
                         h(
                           NButton,
                           { size: 'small', quaternary: true, type: 'primary' },
-                          { default: () => '启用' },
+                          { default: () => t('启用', 'Enable') },
                         ),
-                      default: () => `启用用户 ${userLabel(row)} 并恢复其 API KEY？`,
+                      default: () => t(`启用用户 ${userLabel(row)} 并恢复其 API KEY？`, `Enable user ${userLabel(row)} and restore their API keys?`),
                     },
                   )
                 : h(
@@ -447,16 +449,16 @@ const columns: DataTableColumns<UserSummary> = [
                         h(
                           NButton,
                           { size: 'small', quaternary: true, type: 'warning' },
-                          { default: () => '禁用' },
+                          { default: () => t('禁用', 'Disable') },
                         ),
-                      default: () => `禁用用户 ${userLabel(row)} 并从 CPA 移除其 API KEY？`,
+                      default: () => t(`禁用用户 ${userLabel(row)} 并从 CPA 移除其 API KEY？`, `Disable user ${userLabel(row)} and remove their API keys from CPA?`),
                     },
                   ),
           ],
         },
       ),
   },
-]
+])
 
 onMounted(refresh)
 </script>
@@ -465,12 +467,12 @@ onMounted(refresh)
   <section class="page">
     <div class="page-header">
       <div>
-        <h1 class="page-title">用户管理</h1>
-        <p class="page-subtitle">管理用户昵称、登录账号、密码和角色</p>
+        <h1 class="page-title">{{ t('用户管理', 'User Management') }}</h1>
+        <p class="page-subtitle">{{ t('管理用户昵称、登录账号、密码和角色', 'Manage user nicknames, sign-in accounts, passwords, and roles') }}</p>
       </div>
       <NSpace>
-        <NButton secondary :loading="isLoading" @click="refresh">刷新</NButton>
-        <NButton type="primary" @click="openCreateUser">增加用户</NButton>
+        <NButton secondary :loading="isLoading" @click="refresh">{{ t('刷新', 'Refresh') }}</NButton>
+        <NButton type="primary" @click="openCreateUser">{{ t('增加用户', 'Add user') }}</NButton>
       </NSpace>
     </div>
 
@@ -502,54 +504,54 @@ onMounted(refresh)
       preset="card"
       :mask-closable="false"
       :closable="false"
-      :title="editingUserId ? '编辑用户' : '增加用户'"
+      :title="editingUserId ? t('编辑用户', 'Edit user') : t('增加用户', 'Add user')"
       :style="{ width: 'min(520px, calc(100vw - 32px))' }"
     >
       <NAlert v-if="editingUserId === null" type="warning" :bordered="false" class="user-editor-warning">
-        账号一旦创建，不允许删除，只允许禁用，请谨慎操作。
+        {{ t('账号一旦创建，不允许删除，只允许禁用，请谨慎操作。', 'Accounts cannot be deleted after creation. They can only be disabled, so proceed carefully.') }}
       </NAlert>
 
       <NForm label-placement="top">
-        <NFormItem label="用户昵称" required>
+        <NFormItem :label="t('用户昵称', 'User nickname')" required>
           <NInput
             v-model:value="userNickname"
-            placeholder="例如：研发用户"
+            :placeholder="t('例如：研发用户', 'Example: Engineering user')"
             @keyup.enter="saveUser"
           />
         </NFormItem>
-        <NFormItem label="账号" required>
+        <NFormItem :label="t('账号', 'Account')" required>
           <NInput
             v-model:value="userAccount"
             autocomplete="username"
             :disabled="editingUserId !== null"
-            placeholder="例如：user001"
+            :placeholder="t('例如：user001', 'Example: user001')"
             @keyup.enter="saveUser"
           />
         </NFormItem>
-        <NFormItem label="密码" :required="editingUserId === null">
+        <NFormItem :label="t('密码', 'Password')" :required="editingUserId === null">
           <NInput
             v-model:value="userPassword"
             type="password"
             show-password-on="mousedown"
             autocomplete="new-password"
-            :placeholder="editingUserId ? '留空不修改密码' : '请输入登录密码'"
+            :placeholder="editingUserId ? t('留空不修改密码', 'Leave blank to keep the current password') : t('请输入登录密码', 'Enter a sign-in password')"
             @keyup.enter="saveUser"
           />
         </NFormItem>
-        <NFormItem label="是否设为管理员">
+        <NFormItem :label="t('是否设为管理员', 'Set as admin')">
           <NSwitch v-model:value="isUserAdmin" :disabled="isEditingFirstUser" />
         </NFormItem>
-        <NFormItem label="余额设置">
+        <NFormItem :label="t('余额设置', 'Balance settings')">
           <div class="quota-unlimited-row">
             <div>
-              <div class="quota-unlimited-title">不限制余额</div>
-              <div class="quota-unlimited-desc">开启后不扣余额，也不会因余额暂停 API Key。</div>
+              <div class="quota-unlimited-title">{{ t('不限制余额', 'Unlimited balance') }}</div>
+              <div class="quota-unlimited-desc">{{ t('开启后不扣余额，也不会因余额暂停 API Key。', 'When enabled, balances are not deducted and API keys are not paused due to balance.') }}</div>
             </div>
             <NSwitch v-model:value="quotaUnlimited" />
           </div>
         </NFormItem>
         <div class="form-grid quota-editor-grid">
-          <NFormItem label="不限时余额 USD">
+          <NFormItem :label="t('不限时余额 USD', 'Lifetime balance USD')">
             <NInputNumber
               :value="quotaLifetimeUsd"
               :disabled="quotaUnlimited"
@@ -559,7 +561,7 @@ onMounted(refresh)
               @update:value="setQuotaLifetimeUsd"
             />
           </NFormItem>
-          <NFormItem label="每月余额 USD">
+          <NFormItem :label="t('每月余额 USD', 'Monthly balance USD')">
             <NInputNumber
               :value="quotaMonthlyUsd"
               :disabled="quotaUnlimited"
@@ -571,12 +573,12 @@ onMounted(refresh)
           </NFormItem>
         </div>
         <NAlert type="info" :bordered="false" class="quota-editor-hint">
-          关闭不限制后，扣费顺序：先扣每月余额，不足部分再扣不限时余额；两者都无剩余时暂停该用户的 API Key。
+          {{ t('关闭不限制后，扣费顺序：先扣每月余额，不足部分再扣不限时余额；两者都无剩余时暂停该用户的 API Key。', 'After unlimited balance is disabled, charges are deducted from monthly balance first, then lifetime balance. If neither has remaining balance, the user API keys are paused.') }}
         </NAlert>
         <div class="user-editor-actions">
-          <NButton secondary @click="editorVisible = false">取消</NButton>
+          <NButton secondary @click="editorVisible = false">{{ t('取消', 'Cancel') }}</NButton>
           <NButton type="primary" :loading="isSavingUser" @click="saveUser">
-            {{ editingUserId ? '保存' : '创建' }}
+            {{ editingUserId ? t('保存', 'Save') : t('创建', 'Create') }}
           </NButton>
         </div>
       </NForm>

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -1,3 +1,5 @@
+import { localizedApiErrorMessage } from '@/shared/i18n'
+
 interface ApiErrorPayload {
   detail?: {
     code?: string
@@ -16,13 +18,13 @@ function isApiErrorPayload(value: unknown): value is ApiErrorPayload {
 async function parseError(response: Response): Promise<string> {
   try {
     const data: unknown = await response.json()
-    if (isApiErrorPayload(data) && data.detail?.message) {
-      return data.detail.message
+    if (isApiErrorPayload(data)) {
+      return localizedApiErrorMessage(data.detail?.code, data.detail?.message)
     }
   } catch {
-    return response.statusText || '请求失败'
+    return localizedApiErrorMessage(null, null)
   }
-  return response.statusText || '请求失败'
+  return localizedApiErrorMessage(null, null)
 }
 
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {

--- a/frontend/src/shared/i18n/index.ts
+++ b/frontend/src/shared/i18n/index.ts
@@ -1,0 +1,37 @@
+import {
+  currentLanguage,
+  isEnglish,
+  localize,
+  setLanguage,
+  toggleLanguage,
+  useLanguagePreference,
+} from './language'
+import { copiedText, errorText, localizedKeeperStatusDetail, localizedServerMessage } from './messages'
+
+export {
+  currentLanguage,
+  isEnglish,
+  localize,
+  setLanguage,
+  toggleLanguage,
+  useLanguagePreference,
+  type AppLanguage,
+} from './language'
+export { copiedText, errorText, localizedApiErrorMessage, localizedKeeperStatusDetail, localizedServerMessage } from './messages'
+
+export function useI18n() {
+  return {
+    copiedText,
+    currentLanguage,
+    errorText,
+    isEnglish,
+    keeperStatusText: localizedKeeperStatusDetail,
+    language: currentLanguage,
+    localize,
+    serverText: localizedServerMessage,
+    setLanguage,
+    t: localize,
+    toggleLanguage,
+    useLanguagePreference,
+  }
+}

--- a/frontend/src/shared/i18n/language.ts
+++ b/frontend/src/shared/i18n/language.ts
@@ -1,0 +1,86 @@
+import { computed, ref, watch } from 'vue'
+
+export type AppLanguage = 'zh' | 'en'
+
+const storageKey = 'cpa-helper-language'
+const supportedLanguages = new Set<AppLanguage>(['zh', 'en'])
+
+function normalizeLanguage(value: string | null | undefined): AppLanguage | null {
+  if (!value) {
+    return null
+  }
+  const normalized = value.toLowerCase()
+  if (normalized.startsWith('zh')) {
+    return 'zh'
+  }
+  if (normalized.startsWith('en')) {
+    return 'en'
+  }
+  return null
+}
+
+function getStoredLanguage(): AppLanguage | null {
+  if (typeof localStorage === 'undefined') {
+    return null
+  }
+  try {
+    const stored = localStorage.getItem(storageKey)
+    return supportedLanguages.has(stored as AppLanguage) ? (stored as AppLanguage) : null
+  } catch {
+    return null
+  }
+}
+
+function getBrowserLanguage(): AppLanguage {
+  if (typeof navigator === 'undefined') {
+    return 'en'
+  }
+  const candidates = navigator.languages?.length ? navigator.languages : [navigator.language]
+  for (const candidate of candidates) {
+    const language = normalizeLanguage(candidate)
+    if (language) {
+      return language
+    }
+  }
+  return 'en'
+}
+
+export const currentLanguage = ref<AppLanguage>(getStoredLanguage() ?? getBrowserLanguage())
+export const isEnglish = computed(() => currentLanguage.value === 'en')
+
+watch(
+  currentLanguage,
+  (value) => {
+    try {
+      localStorage.setItem(storageKey, value)
+    } catch {
+      // Storage can be unavailable in private or embedded contexts.
+    }
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = value === 'zh' ? 'zh-CN' : 'en'
+    }
+  },
+  { immediate: true },
+)
+
+export function setLanguage(value: AppLanguage) {
+  currentLanguage.value = value
+}
+
+export function toggleLanguage() {
+  currentLanguage.value = currentLanguage.value === 'zh' ? 'en' : 'zh'
+}
+
+export function localize(zh: string, en: string): string {
+  return currentLanguage.value === 'zh' ? zh : en
+}
+
+export function useLanguagePreference() {
+  return {
+    isEnglish,
+    language: currentLanguage,
+    localize,
+    setLanguage,
+    toggleLanguage,
+  }
+}

--- a/frontend/src/shared/i18n/messages.ts
+++ b/frontend/src/shared/i18n/messages.ts
@@ -1,0 +1,391 @@
+import { currentLanguage, localize } from './language'
+
+type MessagePair = readonly [zh: string, en: string]
+type ServerMessagePattern = readonly [RegExp, (match: RegExpMatchArray) => string]
+
+const exactServerMessages: MessagePair[] = [
+  ['请求失败', 'Request failed'],
+  ['复制失败', 'Copy failed'],
+  ['没有可复制的内容', 'Nothing to copy'],
+  ['复制失败，请手动选中后复制', 'Copy failed. Select the text and copy it manually.'],
+  ['登录状态缺少角色信息，请重启后端服务后重新登录', 'Your session is missing role information. Restart the backend and sign in again.'],
+  ['CPA 配置未完成：请先到「系统设置」填写 CLIProxyAPI 地址和管理密钥，再返回 API 密钥页操作。', 'CPA settings are incomplete. Fill in the CLIProxyAPI URL and management key in System Settings, then return to API Keys.'],
+  ['服务器内部错误', 'Internal server error'],
+  ['请求体不是有效 JSON', 'Request body is not valid JSON'],
+  ['请先登录', 'Sign in first'],
+  ['登录会话已失效', 'Your sign-in session has expired'],
+  ['首次登录后必须先修改账号密码', 'Change the account password after first sign-in'],
+  ['需要管理员权限', 'Admin access is required'],
+  ['资源不存在', 'Resource does not exist'],
+  ['用户名或密码不正确', 'Username or password is incorrect'],
+  ['系统尚未初始化，请先创建第一个管理员账号', 'The system is not initialized. Create the first admin account first.'],
+  ['第一个管理员账号已存在', 'The first admin account already exists'],
+  ['需要提供当前密码', 'Current password is required'],
+  ['当前密码不正确', 'Current password is incorrect'],
+  ['请先创建第一个管理员账号', 'Create the first admin account first'],
+  ['尚未运行', 'Not run yet'],
+  ['正在运行多个 Codex Keeper 任务', 'Multiple Codex Keeper tasks are running'],
+  ['正在刷新 Codex 账号', 'Refreshing Codex accounts'],
+  ['正在按条件刷新 Codex 账号', 'Refreshing Codex accounts by condition'],
+  ['正在巡检 Codex 账号', 'Inspecting Codex accounts'],
+  ['巡检完成', 'Inspection complete'],
+  ['缓存时间内没有需要自动刷新的 Codex auth file', 'No Codex auth files need automatic refresh inside the cache window'],
+  ['未发现指定 Codex auth file', 'No matching Codex auth file was found'],
+  ['未发现 Codex auth file', 'No Codex auth files were found'],
+  ['缺少 access token', 'Missing access token'],
+  ['读取 auth file 详情失败', 'Failed to read auth file details'],
+  ['管理密钥未设置，无法运行 Codex Keeper', 'Management key is not set, so Codex Keeper cannot run'],
+]
+
+const serverCodeFallbackMessages = new Map<string, MessagePair>([
+  ['app_error', ['服务器内部错误', 'Internal server error']],
+  ['authentication_failed', ['请先登录', 'Sign in first']],
+  ['conflict', ['请求冲突', 'Request conflict']],
+  ['forbidden', ['需要管理员权限', 'Admin access is required']],
+  ['method_not_allowed', ['请求方法不支持', 'Request method is not allowed']],
+  ['not_found', ['资源不存在', 'Resource does not exist']],
+  ['startup_check_failed', ['启动检查失败', 'Startup check failed']],
+  ['validation_error', ['请求参数无效', 'Invalid request parameters']],
+])
+
+const serverTermTranslations: MessagePair[] = [
+  ['CLIProxyAPI 管理请求', 'CLIProxyAPI management request'],
+  ['CLIProxyAPI 地址和管理密钥', 'CLIProxyAPI URL and management key'],
+  ['CLIProxyAPI 地址', 'CLIProxyAPI URL'],
+  ['管理密钥', 'management key'],
+  ['Codex Keeper 自动启动配置', 'Codex Keeper auto-start settings'],
+  ['Codex Keeper 自动巡检', 'Codex Keeper automatic inspection'],
+  ['Codex Keeper 定时表达式', 'Codex Keeper schedule expression'],
+  ['Codex Keeper 条件刷新配置', 'Codex Keeper conditional refresh settings'],
+  ['Codex Keeper 条件刷新候选', 'Codex Keeper conditional refresh candidates'],
+  ['Codex Keeper 配置', 'Codex Keeper settings'],
+  ['Codex Keeper', 'Codex Keeper'],
+  ['Codex auth file', 'Codex auth file'],
+  ['Codex auth files', 'Codex auth files'],
+  ['auth file 详情', 'auth file details'],
+  ['auth files', 'auth files'],
+  ['auth file', 'auth file'],
+  ['CPA 配置', 'CPA settings'],
+  ['CPA API KEY', 'CPA API key'],
+  ['CPA 可用模型', 'CPA available models'],
+  ['CPA 当前模型', 'CPA current models'],
+  ['CPA 模型列表', 'CPA model list'],
+  ['API KEY 标识', 'API key identifier'],
+  ['API KEY 描述', 'API key description'],
+  ['API KEY 绑定', 'API key binding'],
+  ['API KEY', 'API key'],
+  ['API Key', 'API key'],
+  ['usage 记录', 'usage record'],
+  ['usage 检测', 'usage check'],
+  ['usage 开关', 'usage switch'],
+  ['api-call 管理请求', 'api-call management request'],
+  ['api-call 响应', 'api-call response'],
+  ['模型请求地址', 'model request URL'],
+  ['模型请求', 'model request'],
+  ['模型响应', 'model response'],
+  ['模型列表响应字段', 'model list response field'],
+  ['模型列表响应', 'model list response'],
+  ['模型列表', 'model list'],
+  ['模型价格', 'model prices'],
+  ['请求地址', 'request URL'],
+  ['请求格式', 'request format'],
+  ['请求体', 'request body'],
+  ['测试模型名称', 'test model name'],
+  ['测试模型', 'test model'],
+  ['测试消息', 'test message'],
+  ['远程 usage 开关', 'remote usage switch'],
+  ['远程', 'remote'],
+  ['代理地址', 'proxy URL'],
+  ['价格数据', 'price data'],
+  ['账号名称', 'account name'],
+  ['账号类型', 'account type'],
+  ['账号状态', 'account status'],
+  ['账号巡检', 'account inspection'],
+  ['账号和密码', 'account and password'],
+  ['账号和昵称', 'account and nickname'],
+  ['账号', 'account'],
+  ['用户名', 'username'],
+  ['昵称', 'nickname'],
+  ['密码长度', 'password length'],
+  ['密码', 'password'],
+  ['第一个管理员账号', 'first admin account'],
+  ['第一个用户', 'first user'],
+  ['用户额度', 'user quota'],
+  ['用户列表', 'users'],
+  ['用户', 'user'],
+  ['当前密码', 'current password'],
+  ['登录会话', 'sign-in session'],
+  ['完整密钥', 'full key'],
+  ['原始 API KEY', 'original API key'],
+  ['本地已不存在的 Codex 账号', 'local Codex accounts that no longer exist'],
+  ['Codex 账号', 'Codex accounts'],
+  ['坏凭证', 'bad credential'],
+  ['凭证', 'credential'],
+  ['网络检测', 'network check'],
+  ['网络错误', 'network errors'],
+  ['额度使用率', 'quota usage'],
+  ['额度金额', 'quota amount'],
+  ['额度', 'quota'],
+  ['优先级降级', 'priority lowered'],
+  ['优先级恢复', 'priority restored'],
+  ['优先级', 'priority'],
+  ['类型优先级', 'type priority'],
+  ['巡检账号历史', 'account inspection history'],
+  ['巡检', 'inspection'],
+  ['条件刷新', 'conditional refresh'],
+  ['账号刷新', 'account refresh'],
+  ['刷新', 'refresh'],
+  ['恢复启用', 'restored enabled state'],
+  ['启用', 'enable'],
+  ['禁用', 'disable'],
+  ['缓存', 'cache'],
+  ['健康', 'healthy'],
+  ['跳过', 'skipped'],
+  ['系统设置', 'system settings'],
+  ['设置', 'settings'],
+  ['账户', 'account'],
+  ['可用模型', 'available models'],
+  ['代理配置', 'proxy settings'],
+  ['API 密钥', 'API keys'],
+  ['历史用量', 'usage history'],
+  ['明细', 'records'],
+  ['原始数据', 'raw data'],
+  ['巡检配置', 'inspection settings'],
+  ['正在运行', 'running'],
+  ['正在其他 Keeper 任务处理中', 'being processed by another Keeper task'],
+  ['无效', 'invalid'],
+  ['不存在', 'does not exist'],
+  ['已存在', 'already exists'],
+  ['不能为空', 'is required'],
+  ['不能超过', 'cannot exceed'],
+  ['不能少于', 'must be at least'],
+  ['不能小于', 'cannot be less than'],
+  ['必须是', 'must be'],
+  ['不是有效', 'is not valid'],
+  ['格式不支持', 'format is unsupported'],
+  ['响应缺少', 'response is missing'],
+  ['超出范围', 'is out of range'],
+  ['下载', 'download'],
+  ['查询', 'query'],
+  ['读取', 'read'],
+  ['写入', 'write'],
+  ['保存', 'save'],
+  ['删除', 'delete'],
+  ['同步', 'sync'],
+  ['更新', 'update'],
+  ['创建', 'create'],
+  ['失败', 'failed'],
+  ['成功', 'succeeded'],
+  ['完成', 'complete'],
+  ['：', ': '],
+  ['，', ', '],
+  ['；', '; '],
+  ['。', '.'],
+]
+
+const serverMessagePatterns: ServerMessagePattern[] = [
+  [/^操作失败$/, () => 'Operation failed'],
+  [/^加载(.+)失败$/, ([, subject]) => `Failed to load ${translateTerms(subject ?? '')}`],
+  [/^保存(.+)失败$/, ([, subject]) => `Failed to save ${translateTerms(subject ?? '')}`],
+  [/^删除(.+)失败$/, ([, subject]) => `Failed to delete ${translateTerms(subject ?? '')}`],
+  [/^同步(.+)失败$/, ([, subject]) => `Failed to sync ${translateTerms(subject ?? '')}`],
+  [/^更新(.+)失败$/, ([, subject]) => `Failed to update ${translateTerms(subject ?? '')}`],
+  [/^创建(.+)失败$/, ([, subject]) => `Failed to create ${translateTerms(subject ?? '')}`],
+  [/^(.+)和(.+)不能为空$/, ([, left, right]) => `${translateTerms(left ?? '')} and ${translateTerms(right ?? '')} are required`],
+  [/^(.+)或(.+)不能为空$/, ([, left, right]) => `${translateTerms(left ?? '')} or ${translateTerms(right ?? '')} is required`],
+  [/^(.+)不能为空$/, ([, subject]) => `${translateTerms(subject ?? '')} is required`],
+  [/^(.+)不能超过 (\d+) 个字符$/, ([, subject, count]) => `${translateTerms(subject ?? '')} cannot exceed ${count} characters`],
+  [/^(.+)不能少于 (\d+) 位$/, ([, subject, count]) => `${translateTerms(subject ?? '')} must be at least ${count} characters`],
+  [/^(.+)不能小于 (\d+)$/, ([, subject, count]) => `${translateTerms(subject ?? '')} cannot be less than ${count}`],
+  [/^(.+)超出范围$/, ([, subject]) => `${translateTerms(subject ?? '')} is out of range`],
+  [/^(.+)无效$/, ([, subject]) => `${translateTerms(subject ?? '')} is invalid`],
+  [/^(.+)不存在$/, ([, subject]) => `${translateTerms(subject ?? '')} does not exist`],
+  [/^(.+)已存在$/, ([, subject]) => `${translateTerms(subject ?? '')} already exists`],
+  [/^(.+)不是有效 JSON$/, ([, subject]) => `${translateTerms(subject ?? '')} is not valid JSON`],
+  [/^(.+)响应不是有效 JSON$/, ([, subject]) => `${translateTerms(subject ?? '')} response is not valid JSON`],
+  [/^(.+)响应格式不支持$/, ([, subject]) => `${translateTerms(subject ?? '')} response format is unsupported`],
+  [/^(.+)响应缺少(.+)$/, ([, subject, field]) => `${translateTerms(subject ?? '')} response is missing ${translateTerms(field ?? '')}`],
+  [/^(.+)请求失败：HTTP (\d+)$/, ([, subject, status]) => `${translateTerms(subject ?? '')} request failed: HTTP ${status}`],
+  [/^(.+)请求失败：(.+)$/, ([, subject, detail]) => `${translateTerms(subject ?? '')} request failed: ${translateNested(detail ?? '')}`],
+  [/^(.+)失败：HTTP (\d+)：(.+)$/, ([, subject, status, detail]) => `${translateTerms(subject ?? '')} failed: HTTP ${status}: ${translateNested(detail ?? '')}`],
+  [/^(.+)失败：HTTP (\d+)$/, ([, subject, status]) => `${translateTerms(subject ?? '')} failed: HTTP ${status}`],
+  [/^(.+)失败：(.+)$/, ([, subject, detail]) => `${translateTerms(subject ?? '')} failed: ${translateNested(detail ?? '')}`],
+  [/^(.+)失败$/, ([, subject]) => `${translateTerms(subject ?? '')} failed`],
+  [/^(.+)超时，请检查(.+)$/, ([, subject, detail]) => `${translateTerms(subject ?? '')} timed out. Check ${translateTerms(detail ?? '')}`],
+  [/^URL 必须是有效的 HTTP\/HTTPS 地址$/, () => 'URL must be a valid HTTP/HTTPS URL'],
+  [/^(.+)必须是有效的 http:\/\/ 或 https:\/\/ 地址$/, ([, subject]) => `${translateTerms(subject ?? '')} must be a valid http:// or https:// URL`],
+  [/^(.+)必须使用 http:\/\/ 或 https:\/\/$/, ([, subject]) => `${translateTerms(subject ?? '')} must use http:// or https://`],
+  [/^(.+)不能包含查询参数或锚点$/, ([, subject]) => `${translateTerms(subject ?? '')} cannot contain query parameters or anchors`],
+  [/^(.+)必须是有效的 http:\/\/、https:\/\/ 或 socks5:\/\/ 地址$/, ([, subject]) => `${translateTerms(subject ?? '')} must be a valid http://, https://, or socks5:// URL`],
+  [/^当前 (.+) 缺少完整密钥，无法发起测试$/, ([, subject]) => `The current ${translateTerms(subject ?? '')} is missing the full key and cannot start a test`],
+  [/^用户额度已用尽，API KEY 已暂停，请联系管理员补充额度$/, () => 'User quota is exhausted. API keys are paused; contact an admin to add quota.'],
+  [/^用户额度已用尽，请补充额度后再恢复 API KEY$/, () => 'User quota is exhausted. Add quota before restoring API keys.'],
+  [/^存在无法恢复的 API KEY，请重新绑定后再启用$/, () => 'Some API keys cannot be restored. Rebind them before enabling the user.'],
+  [/^存在无法恢复的 API KEY，请重新绑定后再恢复$/, () => 'Some API keys cannot be restored. Rebind them before restoring.'],
+  [/^API KEY 与 API KEY 标识不匹配$/, () => 'API key does not match the API key identifier'],
+  [/^API KEY 或 API KEY 标识不能为空$/, () => 'API key or API key identifier is required'],
+  [/^未找到完整 API KEY，请粘贴原始 API KEY$/, () => 'Full API key was not found. Paste the original API key.'],
+  [/^生成 API KEY 失败，请重试$/, () => 'Failed to generate API key. Try again.'],
+  [/^第一个用户不能禁用$/, () => 'The first user cannot be disabled'],
+  [/^账号不允许修改$/, () => 'Account cannot be changed'],
+  [/^第一个管理员账号不能取消管理员权限$/, () => 'The first admin account cannot lose admin access'],
+  [/^用户已禁用$/, () => 'User is disabled'],
+  [/^当前 API KEY 缺少完整密钥，无法发起测试$/, () => 'The current API key is missing the full key and cannot start a test'],
+  [/^模型请求失败：HTTP (\d+)：(.+)$/, ([, status, detail]) => `Model request failed: HTTP ${status}: ${translateNested(detail ?? '')}`],
+  [/^模型请求失败：HTTP (\d+)$/, ([, status]) => `Model request failed: HTTP ${status}`],
+  [/^模型请求失败：(.+)$/, ([, detail]) => `Model request failed: ${translateNested(detail ?? '')}`],
+  [/^模型请求超时，请检查模型请求地址或稍后重试$/, () => 'Model request timed out. Check the model request URL or try again later.'],
+  [/^模型响应不是有效 JSON$/, () => 'Model response is not valid JSON'],
+  [/^请求格式不支持$/, () => 'Request format is unsupported'],
+  [/^查询 CPA 可用模型失败：(.+)$/, ([, detail]) => `Failed to query CPA available models: ${translateNested(detail ?? '')}`],
+  [/^CPA 模型列表响应字段 (.+) 不是列表$/, ([, field]) => `CPA model list response field ${field} is not a list`],
+  [/^CPA 模型列表响应缺少模型列表$/, () => 'CPA model list response is missing the model list'],
+  [/^下载 LiteLLM 价格数据失败：HTTP (\d+)$/, ([, status]) => `Failed to download LiteLLM price data: HTTP ${status}`],
+  [/^下载 LiteLLM 价格数据失败$/, () => 'Failed to download LiteLLM price data'],
+  [/^LiteLLM 价格数据不是有效 JSON$/, () => 'LiteLLM price data is not valid JSON'],
+  [/^该 provider\/model 价格已存在$/, () => 'This provider/model price already exists'],
+  [/^provider\/model 不能为空$/, () => 'Provider/model is required'],
+  [/^价格不能为负数$/, () => 'Price cannot be negative'],
+  [/^启用代理时必须填写代理地址$/, () => 'Proxy URL is required when proxy is enabled'],
+  [/^Cron 表达式无效，请使用 5 段格式：分 时 日 月 周$/, () => 'Invalid Cron expression. Use the 5-field format: minute hour day month weekday'],
+  [/^Cron 表达式无效，请使用 5 段格式$/, () => 'Invalid Cron expression. Use the 5-field format'],
+  [/^开始按条件刷新 (\d+) 个 Codex 账号$/, ([, count]) => `Started conditional refresh for ${count} Codex accounts`],
+  [/^开始刷新 (\d+) 个 Codex 账号$/, ([, count]) => `Started refreshing ${count} Codex accounts`],
+  [/^开始 Codex 账号巡检$/, () => 'Started Codex account inspection'],
+  [/^下一轮计划：(.+)$/, ([, time]) => `Next scheduled run: ${time}`],
+  [/^清理本地已不存在的 Codex 账号 (\d+) 个$/, ([, count]) => `Cleaned up ${count} local Codex accounts that no longer exist`],
+  [/^巡检完成：网络错误 (\d+)$/, ([, count]) => `Inspection complete: ${count} network errors`],
+  [/^条件刷新完成：健康 (\d+)，坏凭证禁用 (\d+)，恢复启用 (\d+)，优先级降级 (\d+)，优先级恢复 (\d+)，网络错误 (\d+)，缓存跳过 (\d+)$/, ([, healthy, disabled, restored, degraded, priorityRestored, networkErrors, skipped]) => `Conditional refresh complete: ${healthy} healthy, ${disabled} bad credentials disabled, ${restored} restored, ${degraded} priorities lowered, ${priorityRestored} priorities restored, ${networkErrors} network errors, ${skipped} skipped by cache`],
+  [/^账号刷新完成：健康 (\d+)，凭证异常 (\d+)，恢复启用 (\d+)，优先级降级 (\d+)，优先级恢复 (\d+)，网络错误 (\d+)$/, ([, healthy, credentialErrors, restored, degraded, priorityRestored, networkErrors]) => `Account refresh complete: ${healthy} healthy, ${credentialErrors} credential errors, ${restored} restored, ${degraded} priorities lowered, ${priorityRestored} priorities restored, ${networkErrors} network errors`],
+  [/^巡检完成：健康 (\d+)，坏凭证禁用 (\d+)，恢复启用 (\d+)，优先级降级 (\d+)，网络错误 (\d+)，缓存跳过 (\d+)$/, ([, healthy, disabled, restored, degraded, networkErrors, skipped]) => `Inspection complete: ${healthy} healthy, ${disabled} bad credentials disabled, ${restored} restored, ${degraded} priorities lowered, ${networkErrors} network errors, ${skipped} skipped by cache`],
+  [/^(.+): 巡检正常，类型 (.+)$/, ([, name, accountType]) => `${name}: inspection healthy, type ${accountType}`],
+  [/^(.+): 正在其他 Keeper 任务处理中，跳过$/, ([, name]) => `${name}: skipped because another Keeper task is processing it`],
+  [/^(.+): 缓存时间内已刷新，跳过$/, ([, name]) => `${name}: skipped because it was refreshed inside the cache window`],
+  [/^刷新完成，类型 (.+)$/, ([, accountType]) => `Refresh complete, type ${accountType}`],
+  [/^禁用凭证：(.+)$/, ([, detail]) => `Disabled credential: ${translateNested(detail ?? '')}`],
+  [/^模拟禁用：(.+)$/, ([, detail]) => `Dry run disable: ${translateNested(detail ?? '')}`],
+  [/^刷新发现凭证不可用：(.+)$/, ([, detail]) => `Refresh found unavailable credential: ${translateNested(detail ?? '')}`],
+  [/^凭证不可用：HTTP (\d+)$/, ([, status]) => `Credential unavailable: HTTP ${status}`],
+  [/^网络检测失败：(.+)$/, ([, detail]) => `Network check failed: ${translateNested(detail ?? '')}`],
+  [/^usage 检测失败：HTTP (\d+)$/, ([, status]) => `Usage check failed: HTTP ${status}`],
+  [/^恢复启用：usage 检测恢复 HTTP (\d+)$/, ([, status]) => `Restored enabled state: usage check recovered with HTTP ${status}`],
+  [/^模拟恢复启用：usage 检测恢复 HTTP (\d+)$/, ([, status]) => `Dry run restore enabled state: usage check recovered with HTTP ${status}`],
+  [/^降为低优先级：额度使用率达到阈值 (\d+)%$/, ([, percent]) => `Lowered priority: quota usage reached the ${percent}% threshold`],
+  [/^模拟降为低优先级：额度使用率达到阈值 (\d+)%$/, ([, percent]) => `Dry run lower priority: quota usage reached the ${percent}% threshold`],
+  [/^恢复优先级：priority (-?\d+)$/, ([, priority]) => `Restored priority: priority ${priority}`],
+  [/^模拟恢复优先级：priority (-?\d+)$/, ([, priority]) => `Dry run restore priority: priority ${priority}`],
+  [/^应用类型优先级：(.+) -> priority (-?\d+)$/, ([, accountType, priority]) => `Applied type priority: ${accountType} -> priority ${priority}`],
+  [/^模拟应用类型优先级：(.+) -> priority (-?\d+)$/, ([, accountType, priority]) => `Dry run apply type priority: ${accountType} -> priority ${priority}`],
+  [/^启用 WebSocket 传输失败：(.+)$/, ([, detail]) => `Failed to enable WebSocket transport: ${translateNested(detail ?? '')}`],
+  [/^(.+)已启用 WebSocket 传输$/, ([, name]) => `${name} enabled WebSocket transport`],
+  [/^只能删除已禁用账号$/, () => 'Only disabled accounts can be deleted'],
+  [/^只能设置小于 -1、大于 20，或当前账号类型 (.+) 对应的 priority (-?\d+)$/, ([, accountType, priority]) => `Priority must be less than -1, greater than 20, or the current account type ${accountType} priority ${priority}`],
+  [/^该账号类型没有可设置的系统 priority$/, () => 'This account type has no system priority that can be set'],
+  [/^模拟(.+)$/, ([, action]) => `Dry run: ${translateNested(action ?? '')}`],
+]
+
+function containsHan(value: string): boolean {
+  return /\p{Script=Han}/u.test(value)
+}
+
+function translateTerms(value: string): string {
+  return serverTermTranslations.reduce(
+    (text, [zh, en]) => text.split(zh).join(en),
+    value,
+  )
+}
+
+function translateNested(value: string): string {
+  return translateKnownServerMessage(value) ?? translateTerms(value)
+}
+
+function translateKnownServerMessage(message: string): string | null {
+  const exact = exactServerMessages.find(([zh]) => zh === message)
+  if (exact) {
+    return exact[1]
+  }
+
+  for (const [pattern, translate] of serverMessagePatterns) {
+    const match = message.match(pattern)
+    if (match) {
+      return translate(match)
+    }
+  }
+
+  const termTranslated = translateTerms(message)
+  if (termTranslated !== message) {
+    return termTranslated
+  }
+
+  return null
+}
+
+export function localizedServerMessage(
+  message: string,
+  fallbackZh = '请求失败',
+  fallbackEn = 'Request failed',
+): string {
+  if (currentLanguage.value === 'zh') {
+    return message || fallbackZh
+  }
+
+  if (!message) {
+    return fallbackEn
+  }
+
+  if (!containsHan(message)) {
+    return message
+  }
+
+  const translated = translateKnownServerMessage(message)
+  if (translated) {
+    return containsHan(translated) ? `${fallbackEn}: ${translated}` : translated
+  }
+
+  return `${fallbackEn}: ${message}`
+}
+
+export function localizedApiErrorMessage(
+  code: string | null | undefined,
+  message: string | null | undefined,
+): string {
+  const fallback = code ? serverCodeFallbackMessages.get(code) : null
+  if (message) {
+    return localizedServerMessage(
+      message,
+      fallback?.[0] ?? '请求失败',
+      fallback?.[1] ?? 'Request failed',
+    )
+  }
+  if (fallback) {
+    return localizedServerMessage('', fallback[0], fallback[1])
+  }
+  return localizedServerMessage('', '请求失败', 'Request failed')
+}
+
+export function localizedKeeperStatusDetail(message: string | null | undefined): string {
+  if (!message) {
+    return localize('未运行', 'Not running')
+  }
+  const normalized = message
+    .replace(/守护运行中/g, localize('自动巡检运行中', 'Automatic inspection running'))
+    .replace(/守护进程/g, localize('后台自动巡检', 'background automatic inspection'))
+    .replace(/守护任务/g, localize('自动巡检任务', 'automatic inspection task'))
+    .replace(/守护已启动/g, localize('已开始自动巡检', 'Automatic inspection started'))
+  return currentLanguage.value === 'zh'
+    ? normalized
+    : localizedServerMessage(normalized, '运行状态', 'Run status')
+}
+
+export function errorText(
+  error: unknown,
+  fallbackZh = '请求失败',
+  fallbackEn = 'Request failed',
+): string {
+  const message = error instanceof Error ? error.message : ''
+  return localizedServerMessage(message, fallbackZh, fallbackEn)
+}
+
+export function copiedText(label: string): string {
+  return localize(`${label} 已复制`, `${label} copied`)
+}

--- a/frontend/src/shared/utils/clipboard.ts
+++ b/frontend/src/shared/utils/clipboard.ts
@@ -1,3 +1,5 @@
+import { localize } from '@/shared/i18n'
+
 function copyWithSelection(text: string): boolean {
   const textArea = document.createElement('textarea')
   const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
@@ -35,7 +37,7 @@ function copyWithSelection(text: string): boolean {
 
 export async function copyToClipboard(text: string): Promise<void> {
   if (!text) {
-    throw new Error('没有可复制的内容')
+    throw new Error(localize('没有可复制的内容', 'Nothing to copy'))
   }
 
   try {
@@ -51,5 +53,7 @@ export async function copyToClipboard(text: string): Promise<void> {
     return
   }
 
-  throw new Error('复制失败，请手动选中后复制')
+  throw new Error(
+    localize('复制失败，请手动选中后复制', 'Copy failed. Select the text and copy it manually.'),
+  )
 }

--- a/frontend/src/shared/utils/format.ts
+++ b/frontend/src/shared/utils/format.ts
@@ -1,9 +1,13 @@
+import { currentLanguage } from '@/shared/i18n'
+
 export function formatInteger(value: number): string {
-  return new Intl.NumberFormat('zh-CN', { maximumFractionDigits: 0 }).format(value)
+  return new Intl.NumberFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
+    maximumFractionDigits: 0,
+  }).format(value)
 }
 
 export function formatCompact(value: number): string {
-  return new Intl.NumberFormat('en-US', {
+  return new Intl.NumberFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     notation: 'compact',
     compactDisplay: 'short',
     maximumFractionDigits: 1,
@@ -63,7 +67,10 @@ export function formatDateTime(
   if (options.includeSecond !== false) {
     formatOptions.second = '2-digit'
   }
-  return new Intl.DateTimeFormat('zh-CN', formatOptions).format(date)
+  return new Intl.DateTimeFormat(
+    currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US',
+    formatOptions,
+  ).format(date)
 }
 
 export function formatLocalDateTimeParam(value: number): string {


### PR DESCRIPTION
## Summary
- Add shared EN/CN language state, a language toggle, and Naive UI locale switching.
- Localize frontend navigation, views, dialogs, validation messages, API/server error messages, formatting, and clipboard feedback.
- Add an i18n smoke test for language detection, persistence, server-message localization, and API error fallback.
- Fix review-found verification fragility in the i18n smoke harness and Keeper log test date handling.

## Code review notes
- Security: no new credential exposure or unsafe HTML injection found; localized user/server text remains rendered through Vue/Naive UI text paths.
- Quality: no blocking issues after the verification fixes in `frontend/scripts/i18n-smoke.mjs` and `backend/internal/app/codex_keeper_test.go`.
- Risk: broad UI text surface; remaining risk is missed/awkward translations in less common backend message variants.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:i18n`
- `go test ./...`
