### PR TITLE
[codex] Publish release images to GHCR too

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,7 +8,9 @@ on:
       - VERSION
 
 env:
-  IMAGE_NAME: walkingd/cpa-helper
+  DOCKERHUB_IMAGE_NAME: walkingd/cpa-helper
+  GHCR_REGISTRY: ghcr.io
+  IMAGE_BASENAME: cpa-helper
 
 jobs:
   version:
@@ -66,10 +68,19 @@ jobs:
     if: github.ref == 'refs/heads/main' && needs.version.outputs.changed == 'true'
     permissions:
       contents: read
+      packages: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Resolve container image names
+        id: image-names
+        shell: bash
+        run: |
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          echo "dockerhub=${DOCKERHUB_IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "ghcr=${GHCR_REGISTRY}/${owner}/${IMAGE_BASENAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -80,6 +91,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Go Docker image
         uses: docker/build-push-action@v7
         with:
@@ -88,8 +106,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ needs.version.outputs.tag }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ steps.image-names.outputs.dockerhub }}:${{ needs.version.outputs.tag }}
+            ${{ steps.image-names.outputs.dockerhub }}:latest
+            ${{ steps.image-names.outputs.ghcr }}:${{ needs.version.outputs.tag }}
+            ${{ steps.image-names.outputs.ghcr }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.version.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## What changed
- Added GHCR login to the release image build job.
- Pushes the same version tag and `latest` tag to both Docker Hub and GHCR.
- Grants the build job `packages: write` and adds OCI labels for the published image.

## Why
The release workflow previously published container images only to Docker Hub. This adds GitHub Container Registry as a second publishing target while preserving the existing Docker Hub behavior.

Having a GHCR mirror also gives users a backup pull source for updates when Docker Hub pull rate limits are hit or Docker Hub availability becomes a bottleneck.

## Validation
- Parsed `.github/workflows/build-and-release.yml` with PyYAML and asserted both Docker Hub and GHCR tags are configured.
- Ran `actionlint` via `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build-and-release.yml`.

## Not tested
- Live workflow execution against Docker Hub/GHCR; this will require a VERSION-change run on `main` after merge.
