### PR TITLE
feat: 优化耗时显示，超过1秒时自动转换为秒(s)

### DIFF
--- a/frontend/src/features/usage/views/UsageHistoryView.vue
+++ b/frontend/src/features/usage/views/UsageHistoryView.vue
@@ -700,6 +700,9 @@ function formatLatency(value: number | null | undefined): string {
   if (value === null || value === undefined || !Number.isFinite(value) || value <= 0) {
     return '-'
   }
+  if (value >= 1000) {
+    return `${+(value / 1000).toFixed(2)} s`
+  }
   return `${formatInteger(Math.round(value))} ms`
 }
 

--- a/frontend/src/features/usage/views/UsageRecordsView.vue
+++ b/frontend/src/features/usage/views/UsageRecordsView.vue
@@ -609,6 +609,9 @@ function formatLatency(value: number | null): string {
   if (value === null) {
     return '-'
   }
+  if (value >= 1000) {
+    return `${+(value / 1000).toFixed(2)} s`
+  }
   return `${formatInteger(Math.round(value))} ms`
 }
 


### PR DESCRIPTION
在请求明细和历史用量面板中，将大于等于 1000ms 的耗时（首字耗时、总耗时）格式化为秒，提升长耗时情况下的数据可读性。