### PR TITLE
fix(codex-keeper): label quota windows by actual window seconds

### DIFF
--- a/frontend/src/features/codex-keeper/views/CodexKeeperStatusView.vue
+++ b/frontend/src/features/codex-keeper/views/CodexKeeperStatusView.vue
@@ -866,9 +866,31 @@ function quotaWindowLabels(account: CodexKeeperAccount): { primary: string; seco
     return { primary: t('月限额', 'Monthly Limit'), secondary: t('次限额', 'Secondary Limit') }
   }
   if (isPaidQuotaWindow(account)) {
-    return { primary: t('5小时限额', '5-Hour Limit'), secondary: t('周限额', 'Weekly Limit') }
+    // The upstream usage payload decides the real window length; the plan
+    // type alone does not. Pro accounts, for example, can report a weekly
+    // primary window, so label by actual seconds and only fall back to the
+    // conventional 5-hour/weekly pair when the seconds are unknown.
+    const primaryLabel = quotaWindowLabelForSeconds(quotaWindowSecondsFor(account, 'primary'))
+    const secondaryLabel = quotaWindowLabelForSeconds(quotaWindowSecondsFor(account, 'secondary'))
+    return {
+      primary: primaryLabel ?? t('5小时限额', '5-Hour Limit'),
+      secondary: secondaryLabel ?? t('周限额', 'Weekly Limit'),
+    }
   }
   return { primary: t('主', 'Primary'), secondary: t('次', 'Secondary') }
+}
+
+function quotaWindowLabelForSeconds(seconds: number | null): string | null {
+  if (seconds === CODEX_FIVE_HOUR_WINDOW_SECONDS) {
+    return t('5小时限额', '5-Hour Limit')
+  }
+  if (seconds === CODEX_WEEK_WINDOW_SECONDS) {
+    return t('周限额', 'Weekly Limit')
+  }
+  if (seconds === CODEX_MONTH_WINDOW_SECONDS) {
+    return t('月限额', 'Monthly Limit')
+  }
+  return null
 }
 
 function shouldShowQuotaWindow(account: CodexKeeperAccount): boolean {


### PR DESCRIPTION
## 问题

账号状态页对所有付费套餐硬编码 `5小时限额 / 周限额` 标签（`quotaWindowLabels()` 只按套餐类型判断）。但窗口真实长度来自上游 usage 返回的 `primary_window_seconds`，pro 类账号的 primary window 可能是 7 天——页面会把周窗口的数据贴上"5小时限额"标签（重置时间距今数天可证）。

## 修复

按实际 `window_seconds` 选标签（18000→5小时限额、604800→周限额、2592000→月限额），秒数未知时才回退到传统 5小时/周 标签对。`vue-tsc --noEmit` 通过。