### PR TITLE
fix(usage): show success rates with two decimals

### DIFF
--- a/frontend/src/features/usage/views/UsageHistoryView.vue
+++ b/frontend/src/features/usage/views/UsageHistoryView.vue
@@ -680,7 +680,8 @@ function distributionLegendItems(items: DistributionItem[]): DistributionLegendI
 function formatPercent(value: number): string {
   return new Intl.NumberFormat(currentLanguage.value === 'zh' ? 'zh-CN' : 'en-US', {
     style: 'percent',
-    maximumFractionDigits: value > 0 && value < 0.1 ? 1 : 0,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   }).format(value)
 }
 


### PR DESCRIPTION
Fixes the usage history success-rate display so values retain two decimal places (for example, 99.74% instead of rounding to 100%).

This is UI-only; it does not change statistics, SQLite, or production configuration.

Validation on the upstream main baseline:
- npm run build: PASS
- npm run lint: PASS
- git diff --check: PASS

Note: the existing upstream i18n smoke command currently exits with Vite `The build was canceled` on a clean baseline and on this patch; no source change was made to that unrelated harness.
